### PR TITLE
Add webhooks to Rustical

### DIFF
--- a/.sqlx/query-14911eb04d6db236b214e23aca1d165a9593f1964d708f6a87bdc297cbf2ded9.json
+++ b/.sqlx/query-14911eb04d6db236b214e23aca1d165a9593f1964d708f6a87bdc297cbf2ded9.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "INSERT OR REPLACE INTO webhook_subscriptions (id, target_url, resource_type, resource_id, secret_key) VALUES (?, ?, ?, ?, ?)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 5
+    },
+    "nullable": []
+  },
+  "hash": "14911eb04d6db236b214e23aca1d165a9593f1964d708f6a87bdc297cbf2ded9"
+}

--- a/.sqlx/query-24005d62e9cdcba11cbfb4c9f3541ea4c481d5e5bdc6b5d848270c98dd0e4885.json
+++ b/.sqlx/query-24005d62e9cdcba11cbfb4c9f3541ea4c481d5e5bdc6b5d848270c98dd0e4885.json
@@ -1,0 +1,44 @@
+{
+  "db_name": "SQLite",
+  "query": "SELECT id, target_url, resource_type, resource_id, secret_key\n                FROM webhook_subscriptions\n                WHERE (resource_type = ? AND resource_id = ?)",
+  "describe": {
+    "columns": [
+      {
+        "name": "id",
+        "ordinal": 0,
+        "type_info": "Text"
+      },
+      {
+        "name": "target_url",
+        "ordinal": 1,
+        "type_info": "Text"
+      },
+      {
+        "name": "resource_type",
+        "ordinal": 2,
+        "type_info": "Text"
+      },
+      {
+        "name": "resource_id",
+        "ordinal": 3,
+        "type_info": "Text"
+      },
+      {
+        "name": "secret_key",
+        "ordinal": 4,
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Right": 2
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true
+    ]
+  },
+  "hash": "24005d62e9cdcba11cbfb4c9f3541ea4c481d5e5bdc6b5d848270c98dd0e4885"
+}

--- a/.sqlx/query-5a4593bf10e2b416976a46e7cab564e84da527f985ad08efe9a7ddf7f16cc8f7.json
+++ b/.sqlx/query-5a4593bf10e2b416976a46e7cab564e84da527f985ad08efe9a7ddf7f16cc8f7.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "DELETE FROM webhook_subscriptions WHERE id = ?",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": []
+  },
+  "hash": "5a4593bf10e2b416976a46e7cab564e84da527f985ad08efe9a7ddf7f16cc8f7"
+}

--- a/.sqlx/query-647843d33e5dd8e1028ef900d0fd975372e4534635a5d795e85dab822701b60d.json
+++ b/.sqlx/query-647843d33e5dd8e1028ef900d0fd975372e4534635a5d795e85dab822701b60d.json
@@ -1,0 +1,44 @@
+{
+  "db_name": "SQLite",
+  "query": "SELECT id, target_url, resource_type, resource_id, secret_key\n                FROM webhook_subscriptions\n                WHERE (id) = (?)",
+  "describe": {
+    "columns": [
+      {
+        "name": "id",
+        "ordinal": 0,
+        "type_info": "Text"
+      },
+      {
+        "name": "target_url",
+        "ordinal": 1,
+        "type_info": "Text"
+      },
+      {
+        "name": "resource_type",
+        "ordinal": 2,
+        "type_info": "Text"
+      },
+      {
+        "name": "resource_id",
+        "ordinal": 3,
+        "type_info": "Text"
+      },
+      {
+        "name": "secret_key",
+        "ordinal": 4,
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true
+    ]
+  },
+  "hash": "647843d33e5dd8e1028ef900d0fd975372e4534635a5d795e85dab822701b60d"
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3002,6 +3002,8 @@ dependencies = [
  "rustical_oidc",
  "rustical_store",
  "rustical_store_sqlite",
+ "rustical_types",
+ "rustical_webhooks",
  "serde",
  "sqlx",
  "tokio",
@@ -3228,6 +3230,7 @@ dependencies = [
  "rustical_dav",
  "rustical_ical",
  "rustical_store_sqlite",
+ "rustical_types",
  "rustical_xml",
  "serde",
  "sha2",
@@ -3252,12 +3255,38 @@ dependencies = [
  "rstest",
  "rustical_ical",
  "rustical_store",
+ "rustical_types",
  "serde",
  "sqlx",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "rustical_types"
+version = "0.10.5"
+dependencies = [
+ "serde_json",
+]
+
+[[package]]
+name = "rustical_webhooks"
+version = "0.10.5"
+dependencies = [
+ "axum",
+ "base64 0.22.1",
+ "hmac",
+ "http",
+ "reqwest",
+ "rustical_ical",
+ "rustical_store",
+ "rustical_types",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3288,6 +3288,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tokio",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3268,6 +3268,7 @@ dependencies = [
 name = "rustical_types"
 version = "0.10.5"
 dependencies = [
+ "serde",
  "serde_json",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,7 +150,6 @@ ece = { version = "2.3", default-features = false, features = [
 ] }
 openssl = { version = "0.10", features = ["vendored"] }
 async-std = { version = "1.13", features = ["attributes"] }
-uuid = { version = "1", features = ["v4"] }
 
 [dependencies]
 rustical_store.workspace = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,6 +150,7 @@ ece = { version = "2.3", default-features = false, features = [
 ] }
 openssl = { version = "0.10", features = ["vendored"] }
 async-std = { version = "1.13", features = ["attributes"] }
+uuid = { version = "1", features = ["v4"] }
 
 [dependencies]
 rustical_store.workspace = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,8 @@ rustical_frontend = { path = "./crates/frontend/" }
 rustical_xml = { path = "./crates/xml/" }
 rustical_oidc = { path = "./crates/oidc/" }
 rustical_ical = { path = "./crates/ical/" }
+rustical_webhooks = { path = "./crates/webhooks/" }
+rustical_types = { path = "./crates/types/" }
 
 matchit = "0.9"
 uuid = { version = "1.11", features = ["v4", "fast-rng"] }
@@ -155,6 +157,8 @@ rustical_store_sqlite.workspace = true
 rustical_caldav.workspace = true
 rustical_carddav.workspace = true
 rustical_frontend.workspace = true
+rustical_webhooks.workspace = true
+rustical_types.workspace = true
 toml.workspace = true
 serde.workspace = true
 tokio.workspace = true

--- a/crates/frontend/js-components/lib/edit-webhooks-form.ts
+++ b/crates/frontend/js-components/lib/edit-webhooks-form.ts
@@ -29,6 +29,22 @@ export class EditWebhooksForm extends LitElement {
     return html`
       <button @click=${() => { this.dialog.value.showModal(); this.load(); }}>Webhooks</button>
       <dialog ${ref(this.dialog)}>
+        <style>
+          form label {
+            display:block;
+            margin:.75rem 0 .25rem;
+            font-weight:600;
+          }
+          form input[type=url],
+          form input[type=text] {
+            display:block;
+            width:100%;
+            box-sizing:border-box;
+            padding:.45rem .55rem;
+            margin:0;
+          }
+          form button { margin-right:.5rem; margin-top:.75rem; }
+        </style>
         <h3>Manage webhooks</h3>
         <div class="subscriptions">
           ${this.subscriptions.length ? html`
@@ -56,17 +72,10 @@ export class EditWebhooksForm extends LitElement {
         <hr>
         <h4>${this.editingId ? 'Edit subscription' : 'Create subscription'}</h4>
         <form @submit=${this.submit} ${ref(this.form)}>
-          <!-- ID removed from form -->
-          <label>
-            Target URL
-            <input type="url" name="target_url" .value=${this.target_url} @input=${(e: any) => this.target_url = e.target.value} required />
-          </label>
-          <br>
-            <label>
-              Secret (optional)
-              <input type="text" name="secret_key" .value=${this.secret_key} @input=${(e: any) => this.secret_key = e.target.value} />
-            </label>
-          <br>
+          <label>Target URL</label>
+          <input type="url" name="target_url" .value=${this.target_url} @input=${(e: any) => this.target_url = e.target.value} required />
+          <label>Secret (optional)</label>
+          <input type="text" name="secret_key" .value=${this.secret_key} @input=${(e: any) => this.secret_key = e.target.value} />
           <button type="submit">${this.editingId ? 'Update' : 'Create'}</button>
           <button @click=${(e: Event) => { e.preventDefault(); this.clearForm(); }} type="button">New</button>
           <button @click=${(e: Event) => { e.preventDefault(); this.dialog.value.close(); }} type="button" class="cancel">Close</button>

--- a/crates/frontend/js-components/lib/edit-webhooks-form.ts
+++ b/crates/frontend/js-components/lib/edit-webhooks-form.ts
@@ -1,0 +1,149 @@
+import { html, LitElement } from "lit";
+import { customElement, property, state } from "lit/decorators.js";
+import { Ref, createRef, ref } from 'lit/directives/ref.js';
+
+interface WebhookSubscription {
+  id: string;
+  target_url: string;
+  resource_type: string;
+  resource_id: string;
+  secret_key?: string | null;
+}
+
+@customElement("edit-webhooks-form")
+export class EditWebhooksForm extends LitElement {
+  protected override createRenderRoot() { return this }
+
+  @property() resource_type: string = ''
+  @property() resource_id: string = ''
+
+  @state() subscriptions: WebhookSubscription[] = []
+  @state() editingId: string | null = null
+  @state() id: string = ''
+  @state() target_url: string = ''
+  @state() secret_key: string = ''
+
+  dialog: Ref<HTMLDialogElement> = createRef()
+  form: Ref<HTMLFormElement> = createRef()
+
+  override render() {
+    return html`
+      <button @click=${() => { this.dialog.value.showModal(); this.load(); }}>Webhooks</button>
+      <dialog ${ref(this.dialog)}>
+        <h3>Manage webhooks</h3>
+        <div class="subscriptions">
+          ${this.subscriptions.length ? html`
+          <table>
+            <thead>
+              <tr>
+                <th>ID</th>
+                <th>Target URL</th>
+                <th>Secret?</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              ${this.subscriptions.map(sub => html`
+                <tr>
+                  <td>${sub.id}</td>
+                  <td>${sub.target_url}</td>
+                  <td>${sub.secret_key ? 'Yes' : 'No'}</td>
+                  <td>
+                    <button @click=${() => this.startEdit(sub)}>Edit</button>
+                    <button @click=${() => this.delete(sub.id)}>Delete</button>
+                  </td>
+                </tr>`)}
+            </tbody>
+          </table>` : html`<p>No webhooks yet.</p>`}
+        </div>
+        <hr>
+        <h4>${this.editingId ? 'Edit subscription' : 'Create subscription'}</h4>
+        <form @submit=${this.submit} ${ref(this.form)}>
+          <label>
+            ID
+            <input type="text" name="id" .value=${this.id} ?disabled=${this.editingId !== null} @input=${(e: any) => this.id = e.target.value} required />
+          </label>
+          <br>
+          <label>
+            Target URL
+            <input type="url" name="target_url" .value=${this.target_url} @input=${(e: any) => this.target_url = e.target.value} required />
+          </label>
+          <br>
+          <label>
+            Secret (optional)
+            <input type="text" name="secret_key" .value=${this.secret_key} @input=${(e: any) => this.secret_key = e.target.value} />
+          </label>
+          <br>
+          <button type="submit">${this.editingId ? 'Update' : 'Create'}</button>
+          <button @click=${(e: Event) => { e.preventDefault(); this.clearForm(); }} type="button">New</button>
+          <button @click=${(e: Event) => { e.preventDefault(); this.dialog.value.close(); }} type="button" class="cancel">Close</button>
+        </form>
+      </dialog>
+    `
+  }
+
+  async load() {
+    if (!this.resource_type || !this.resource_id) return;
+    const resp = await fetch(`/webhooks/subscriptions/${this.resource_type}/${this.resource_id}`)
+    if (resp.ok) {
+      const data = await resp.json()
+      this.subscriptions = data.subscriptions || []
+    } else {
+      alert(`Failed loading subscriptions: ${resp.status}`)
+    }
+  }
+
+  startEdit(sub: WebhookSubscription) {
+    this.editingId = sub.id
+    this.id = sub.id
+    this.target_url = sub.target_url
+    this.secret_key = sub.secret_key || ''
+  }
+
+  clearForm() {
+    this.editingId = null
+    this.id = ''
+    this.target_url = ''
+    this.secret_key = ''
+  }
+
+  async delete(id: string) {
+    if (!confirm(`Delete webhook ${id}?`)) return;
+    const resp = await fetch(`/webhooks/subscriptions/delete/${encodeURIComponent(id)}`, { method: 'DELETE' })
+    if (!resp.ok && resp.status !== 204) {
+      alert(`Failed deleting: ${resp.status}`)
+      return
+    }
+    await this.load()
+    if (this.editingId === id) this.clearForm()
+  }
+
+  async submit(e: SubmitEvent) {
+    e.preventDefault()
+    if (!this.id) { alert('Missing id'); return }
+    if (!this.target_url) { alert('Missing target url'); return }
+    if (!this.resource_type || !this.resource_id) { alert('Missing resource info'); return }
+    const payload = {
+      id: this.id,
+      target_url: this.target_url,
+      resource_type: this.resource_type,
+      resource_id: this.resource_id,
+      secret_key: this.secret_key ? this.secret_key : null
+    }
+    const resp = await fetch('/webhooks/subscriptions/upsert', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    })
+    if (!resp.ok) {
+      alert(`Upsert failed: ${resp.status} ${await resp.text()}`)
+      return
+    }
+    await this.load()
+    this.editingId = this.id // remain in edit mode
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap { 'edit-webhooks-form': EditWebhooksForm }
+}

--- a/crates/frontend/js-components/lib/edit-webhooks-form.ts
+++ b/crates/frontend/js-components/lib/edit-webhooks-form.ts
@@ -30,20 +30,11 @@ export class EditWebhooksForm extends LitElement {
       <button @click=${() => { this.dialog.value.showModal(); this.load(); }}>Webhooks</button>
       <dialog ${ref(this.dialog)}>
         <style>
-          form label {
-            display:block;
-            margin:.75rem 0 .25rem;
-            font-weight:600;
-          }
-          form input[type=url],
-          form input[type=text] {
-            display:block;
-            width:100%;
-            box-sizing:border-box;
-            padding:.45rem .55rem;
-            margin:0;
-          }
-          form button { margin-right:.5rem; margin-top:.75rem; }
+          form .field { margin-bottom: .85rem; }
+          form .field label { display:block; font-weight:600; margin-bottom:.35rem; }
+          form .field input[type=url],
+          form .field input[type=text] { display:block; width:100%; box-sizing:border-box; padding:.45rem .55rem; }
+          form .actions-row { margin-top:.5rem; display:flex; gap:.5rem; flex-wrap:wrap; }
         </style>
         <h3>Manage webhooks</h3>
         <div class="subscriptions">
@@ -72,13 +63,19 @@ export class EditWebhooksForm extends LitElement {
         <hr>
         <h4>${this.editingId ? 'Edit subscription' : 'Create subscription'}</h4>
         <form @submit=${this.submit} ${ref(this.form)}>
-          <label>Target URL</label>
-          <input type="url" name="target_url" .value=${this.target_url} @input=${(e: any) => this.target_url = e.target.value} required />
-          <label>Secret (optional)</label>
-          <input type="text" name="secret_key" .value=${this.secret_key} @input=${(e: any) => this.secret_key = e.target.value} />
-          <button type="submit">${this.editingId ? 'Update' : 'Create'}</button>
-          <button @click=${(e: Event) => { e.preventDefault(); this.clearForm(); }} type="button">New</button>
-          <button @click=${(e: Event) => { e.preventDefault(); this.dialog.value.close(); }} type="button" class="cancel">Close</button>
+          <div class="field">
+            <label>Target URL</label>
+            <input type="url" name="target_url" .value=${this.target_url} @input=${(e: any) => this.target_url = e.target.value} required />
+          </div>
+          <div class="field">
+            <label>Secret (optional)</label>
+            <input type="text" name="secret_key" .value=${this.secret_key} @input=${(e: any) => this.secret_key = e.target.value} />
+          </div>
+          <div class="actions-row">
+            <button type="submit">${this.editingId ? 'Update' : 'Create'}</button>
+            <button @click=${(e: Event) => { e.preventDefault(); this.clearForm(); }} type="button">New</button>
+            <button @click=${(e: Event) => { e.preventDefault(); this.dialog.value.close(); }} type="button" class="cancel">Close</button>
+          </div>
         </form>
       </dialog>
     `

--- a/crates/frontend/js-components/lib/edit-webhooks-form.ts
+++ b/crates/frontend/js-components/lib/edit-webhooks-form.ts
@@ -35,7 +35,6 @@ export class EditWebhooksForm extends LitElement {
           <table>
             <thead>
               <tr>
-                <th>ID</th>
                 <th>Target URL</th>
                 <th>Secret?</th>
                 <th>Actions</th>
@@ -44,7 +43,6 @@ export class EditWebhooksForm extends LitElement {
             <tbody>
               ${this.subscriptions.map(sub => html`
                 <tr>
-                  <td>${sub.id}</td>
                   <td>${sub.target_url}</td>
                   <td>${sub.secret_key ? 'Yes' : 'No'}</td>
                   <td>
@@ -58,21 +56,16 @@ export class EditWebhooksForm extends LitElement {
         <hr>
         <h4>${this.editingId ? 'Edit subscription' : 'Create subscription'}</h4>
         <form @submit=${this.submit} ${ref(this.form)}>
-          ${this.editingId ? html`
-            <div>
-              <label>ID
-                <input type="text" .value=${this.editingId} disabled />
-              </label>
-            </div>` : ''}
+          <!-- ID removed from form -->
           <label>
             Target URL
             <input type="url" name="target_url" .value=${this.target_url} @input=${(e: any) => this.target_url = e.target.value} required />
           </label>
           <br>
-          <label>
-            Secret (optional)
-            <input type="text" name="secret_key" .value=${this.secret_key} @input=${(e: any) => this.secret_key = e.target.value} />
-          </label>
+            <label>
+              Secret (optional)
+              <input type="text" name="secret_key" .value=${this.secret_key} @input=${(e: any) => this.secret_key = e.target.value} />
+            </label>
           <br>
           <button type="submit">${this.editingId ? 'Update' : 'Create'}</button>
           <button @click=${(e: Event) => { e.preventDefault(); this.clearForm(); }} type="button">New</button>

--- a/crates/frontend/js-components/vite.config.ts
+++ b/crates/frontend/js-components/vite.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
         "lib/edit-addressbook-form.ts",
         "lib/import-addressbook-form.ts",
         "lib/delete-button.ts",
+        "lib/edit-webhooks-form.ts",
       ],
       output: {
         dir: "../public/assets/js/",

--- a/crates/frontend/public/assets/dev-addressbooks-alignment.html
+++ b/crates/frontend/public/assets/dev-addressbooks-alignment.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Addressbooks Alignment Demo</title>
+  <link rel="stylesheet" href="./style.css" />
+  <style>
+    body { padding: 16px; font-family: system-ui, sans-serif; }
+    h2 { margin-top: 0; }
+    ul.collection-list { list-style: none; padding: 0; }
+    li.collection-list-item { margin: 12px 0; border: 1px solid var(--border-color, #ccc); border-radius: 8px; }
+  </style>
+</head>
+<body>
+  <h2>demo-user's Addressbooks (Alignment Test)</h2>
+  <ul class="collection-list">
+    <!-- Addressbook 1 -->
+    <li class="collection-list-item">
+      <a href="#"></a>
+      <div class="inner">
+        <span class="title">contacts</span>
+        <span class="description">Personal contacts</span>
+        <div class="actions">
+          <form action="#" method="GET"><button type="submit">Download</button></form>
+          <edit-addressbook-form
+            principal="demo-user"
+            addr_id="contacts"
+            displayname="Contacts"
+            description="Personal contacts"
+          ></edit-addressbook-form>
+          <edit-webhooks-form resource_type="addressbook" resource_id="contacts"></edit-webhooks-form>
+          <delete-button trash href="#"></delete-button>
+        </div>
+        <div class="metadata">120 (48 KB) objects, 2 (1 KB) deleted</div>
+      </div>
+    </li>
+    <!-- Addressbook 2 -->
+    <li class="collection-list-item">
+      <a href="#"></a>
+      <div class="inner">
+        <span class="title">team</span>
+        <span class="description">Team shared contacts</span>
+        <div class="actions">
+          <form action="#" method="GET"><button type="submit">Download</button></form>
+          <edit-addressbook-form
+            principal="demo-user"
+            addr_id="team"
+            displayname="Team"
+            description="Team shared contacts"
+          ></edit-addressbook-form>
+          <edit-webhooks-form resource_type="addressbook" resource_id="team"></edit-webhooks-form>
+          <delete-button trash href="#"></delete-button>
+        </div>
+        <div class="metadata">45 (10 KB) objects, 0 deleted</div>
+      </div>
+    </li>
+  </ul>
+
+  <!-- Scripts -->
+  <script type="module" src="./js/edit-addressbook-form.mjs"></script>
+  <script type="module" src="./js/edit-webhooks-form.mjs"></script>
+  <script type="module" src="./js/delete-button.mjs"></script>
+  <script type="module">
+    // Mock fetch for addressbook and webhook interactions
+    const origFetch = window.fetch.bind(window);
+    window.fetch = async (url, opts = {}) => {
+      if (url.startsWith('/carddav/principal/')) {
+        return new Response('OK', { status: 200 });
+      }
+      if (url.startsWith('/webhooks/subscriptions/')) {
+        if (url.includes('/upsert')) {
+          const body = JSON.parse(opts.body || '{}');
+          return new Response(JSON.stringify({ id: body.id || 'generated-id', updated: false, status: 'created' }), { status: 201 });
+        }
+        if (url.includes('/delete/')) {
+          return new Response('Unregistered', { status: 204 });
+        }
+        const parts = url.split('/');
+        const resource_type = parts[3];
+        const resource_id = parts[4];
+        return new Response(JSON.stringify({ subscriptions: [] }), { status: 200 });
+      }
+      return origFetch(url, opts);
+    };
+  </script>
+</body>
+</html>

--- a/crates/frontend/public/assets/dev-calendars-alignment.html
+++ b/crates/frontend/public/assets/dev-calendars-alignment.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Calendars Alignment Demo</title>
+  <link rel="stylesheet" href="./style.css" />
+  <style>
+    body { padding: 16px; font-family: system-ui, sans-serif; }
+    h2 { margin-top: 0; }
+    ul.collection-list { list-style: none; padding: 0; }
+    li.collection-list-item { margin: 12px 0; border: 1px solid var(--border-color, #ccc); border-radius: 8px; }
+    .color-chip { border-radius: 0 8px 8px 0; }
+  </style>
+</head>
+<body>
+  <h2>demo-user's Calendars (Alignment Test)</h2>
+  <ul class="collection-list">
+    <!-- Calendar 1 -->
+    <li class="collection-list-item" style="--color: #3b82f6;">
+      <a href="#"></a>
+      <div class="inner">
+        <span class="title">work-calendar
+          <div class="component-chips"><span class="chip">VEVENT</span><span class="chip">VTODO</span></div>
+        </span>
+        <span class="description">Work related events</span>
+        <div class="actions">
+          <form action="#" method="GET"><button type="submit">Download</button></form>
+          <edit-calendar-form
+            principal="demo-user"
+            cal_id="work"
+            timezone_id="UTC"
+            displayname="Work Calendar"
+            description="Work related events"
+            color="#3b82f6"
+            components='["VEVENT","VTODO"]'
+          ></edit-calendar-form>
+          <edit-webhooks-form resource_type="calendar" resource_id="work"></edit-webhooks-form>
+          <delete-button trash href="#"></delete-button>
+        </div>
+        <div class="metadata">42 (12 KB) objects, 0 deleted</div>
+        <div class="color-chip"></div>
+      </div>
+    </li>
+    <!-- Calendar 2 -->
+    <li class="collection-list-item" style="--color: #10b981;">
+      <a href="#"></a>
+      <div class="inner">
+        <span class="title">personal-calendar
+          <div class="component-chips"><span class="chip">VEVENT</span></div>
+        </span>
+        <span class="description">Personal events</span>
+        <div class="actions">
+          <form action="#" method="GET"><button type="submit">Download</button></form>
+          <edit-calendar-form
+            principal="demo-user"
+            cal_id="personal"
+            timezone_id="Europe/Berlin"
+            displayname="Personal Calendar"
+            description="Personal events"
+            color="#10b981"
+            components='["VEVENT"]'
+          ></edit-calendar-form>
+          <edit-webhooks-form resource_type="calendar" resource_id="personal"></edit-webhooks-form>
+          <delete-button trash href="#"></delete-button>
+        </div>
+        <div class="metadata">15 (4 KB) objects, 1 (0.2 KB) deleted</div>
+        <div class="color-chip"></div>
+      </div>
+    </li>
+  </ul>
+
+  <!-- Scripts -->
+  <script type="module" src="./js/edit-calendar-form.mjs"></script>
+  <script type="module" src="./js/edit-webhooks-form.mjs"></script>
+  <script type="module" src="./js/delete-button.mjs"></script>
+  <script type="module">
+    // Mock fetch so forms don't error.
+    const origFetch = window.fetch.bind(window);
+    window.fetch = async (url, opts = {}) => {
+      if (url.startsWith('/caldav/principal/')) {
+        return new Response('OK', { status: 200 });
+      }
+      if (url.startsWith('/webhooks/subscriptions/')) {
+        if (url.includes('/upsert')) {
+          const body = JSON.parse(opts.body || '{}');
+          return new Response(JSON.stringify({ id: body.id || 'generated-id', updated: false, status: 'created' }), { status: 201 });
+        }
+        if (url.includes('/delete/')) {
+          return new Response('Unregistered', { status: 204 });
+        }
+        // list endpoint pattern /webhooks/subscriptions/:resource_type/:resource_id
+        const parts = url.split('/');
+        const resource_type = parts[3];
+        const resource_id = parts[4];
+        return new Response(JSON.stringify({ subscriptions: [] }), { status: 200 });
+      }
+      return origFetch(url, opts);
+    };
+  </script>
+</body>
+</html>

--- a/crates/frontend/public/assets/dev-webhooks-test.html
+++ b/crates/frontend/public/assets/dev-webhooks-test.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Webhook Subscriptions Test</title>
+  <style>
+    body { font-family: system-ui, sans-serif; padding: 1rem; }
+    table { border-collapse: collapse; width: 100%; margin-bottom: 1rem; }
+    th, td { border: 1px solid #ccc; padding: 0.4rem; font-size: 0.9rem; }
+    dialog { border: 1px solid #666; padding: 1rem; }
+    button { margin-right: 0.25rem; }
+  </style>
+</head>
+<body>
+  <h1>Standalone Webhooks Component Demo</h1>
+  <p>This page mocks the backend API so you can test the UI without running the full server.</p>
+
+  <edit-webhooks-form resource_type="calendar" resource_id="demo-cal"></edit-webhooks-form>
+
+  <script type="module" src="./js/edit-webhooks-form.mjs"></script>
+  <script type="module">
+    // Simple in-memory mock store
+    const store = new Map();
+    // Seed example data
+    store.set('sub-1', { id: 'sub-1', target_url: 'https://example.com/hook1', resource_type: 'calendar', resource_id: 'demo-cal', secret_key: null });
+    store.set('sub-2', { id: 'sub-2', target_url: 'https://example.com/hook2', resource_type: 'calendar', resource_id: 'demo-cal', secret_key: 'sekret' });
+
+    const delay = ms => new Promise(r => setTimeout(r, ms));
+
+    const origFetch = window.fetch.bind(window);
+    window.fetch = async (url, opts = {}) => {
+      const { method = 'GET' } = opts;
+      // List
+      const listMatch = url.match(/\/webhooks\/subscriptions\/([^/]+)\/([^/]+)/);
+      if (method === 'GET' && listMatch) {
+        const [, resource_type, resource_id] = listMatch;
+        const subs = Array.from(store.values()).filter(s => s.resource_type === resource_type && s.resource_id === resource_id);
+        return new Response(JSON.stringify({ subscriptions: subs }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      // Get by id
+      const getMatch = url.match(/\/webhooks\/subscriptions\/id\/([^/]+)/);
+      if (method === 'GET' && getMatch) {
+        const [, id] = getMatch;
+        if (!store.has(id)) return new Response('Not found', { status: 404 });
+        return new Response(JSON.stringify(store.get(id)), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      // Upsert
+      if (method === 'POST' && url === '/webhooks/subscriptions/upsert') {
+        const body = JSON.parse(opts.body || '{}');
+        store.set(body.id, body);
+        return new Response(JSON.stringify({ id: body.id, updated: true, status: 'updated' }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      // Delete
+      const delMatch = url.match(/\/webhooks\/subscriptions\/delete\/([^/]+)/);
+      if (method === 'DELETE' && delMatch) {
+        const [, id] = delMatch;
+        store.delete(id);
+        return new Response('Unregistered', { status: 204 });
+      }
+      return origFetch(url, opts);
+    };
+  </script>
+</body>
+</html>

--- a/crates/frontend/public/assets/dev-webhooks-test.html
+++ b/crates/frontend/public/assets/dev-webhooks-test.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <title>Webhook Subscriptions Test</title>
+  <link rel="stylesheet" href="./style.css" />
   <style>
     body { font-family: system-ui, sans-serif; padding: 1rem; }
     table { border-collapse: collapse; width: 100%; margin-bottom: 1rem; }

--- a/crates/frontend/public/assets/js/edit-webhooks-form.mjs
+++ b/crates/frontend/public/assets/js/edit-webhooks-form.mjs
@@ -1,0 +1,194 @@
+import { i, x } from "./lit-DkXrt_Iv.mjs";
+import { n, t } from "./property-B8WoKf1Y.mjs";
+import { e, n as n$1 } from "./ref-BwbQvJBB.mjs";
+/**
+ * @license
+ * Copyright 2017 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+function r(r2) {
+  return n({ ...r2, state: true, attribute: false });
+}
+var __defProp = Object.defineProperty;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __decorateClass = (decorators, target, key, kind) => {
+  var result = kind > 1 ? void 0 : kind ? __getOwnPropDesc(target, key) : target;
+  for (var i2 = decorators.length - 1, decorator; i2 >= 0; i2--)
+    if (decorator = decorators[i2])
+      result = (kind ? decorator(target, key, result) : decorator(result)) || result;
+  if (kind && result) __defProp(target, key, result);
+  return result;
+};
+let EditWebhooksForm = class extends i {
+  constructor() {
+    super(...arguments);
+    this.resource_type = "";
+    this.resource_id = "";
+    this.subscriptions = [];
+    this.editingId = null;
+    this.id = "";
+    this.target_url = "";
+    this.secret_key = "";
+    this.dialog = e();
+    this.form = e();
+  }
+  createRenderRoot() {
+    return this;
+  }
+  render() {
+    return x`
+      <button @click=${() => {
+      this.dialog.value.showModal();
+      this.load();
+    }}>Webhooks</button>
+      <dialog ${n$1(this.dialog)}>
+        <h3>Manage webhooks</h3>
+        <div class="subscriptions">
+          ${this.subscriptions.length ? x`
+          <table>
+            <thead>
+              <tr>
+                <th>ID</th>
+                <th>Target URL</th>
+                <th>Secret?</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              ${this.subscriptions.map((sub) => x`
+                <tr>
+                  <td>${sub.id}</td>
+                  <td>${sub.target_url}</td>
+                  <td>${sub.secret_key ? "Yes" : "No"}</td>
+                  <td>
+                    <button @click=${() => this.startEdit(sub)}>Edit</button>
+                    <button @click=${() => this.delete(sub.id)}>Delete</button>
+                  </td>
+                </tr>`)}
+            </tbody>
+          </table>` : x`<p>No webhooks yet.</p>`}
+        </div>
+        <hr>
+        <h4>${this.editingId ? "Edit subscription" : "Create subscription"}</h4>
+        <form @submit=${this.submit} ${n$1(this.form)}>
+          <label>
+            ID
+            <input type="text" name="id" .value=${this.id} ?disabled=${this.editingId !== null} @input=${(e2) => this.id = e2.target.value} required />
+          </label>
+          <br>
+          <label>
+            Target URL
+            <input type="url" name="target_url" .value=${this.target_url} @input=${(e2) => this.target_url = e2.target.value} required />
+          </label>
+          <br>
+          <label>
+            Secret (optional)
+            <input type="text" name="secret_key" .value=${this.secret_key} @input=${(e2) => this.secret_key = e2.target.value} />
+          </label>
+          <br>
+          <button type="submit">${this.editingId ? "Update" : "Create"}</button>
+          <button @click=${(e2) => {
+      e2.preventDefault();
+      this.clearForm();
+    }} type="button">New</button>
+          <button @click=${(e2) => {
+      e2.preventDefault();
+      this.dialog.value.close();
+    }} type="button" class="cancel">Close</button>
+        </form>
+      </dialog>
+    `;
+  }
+  async load() {
+    if (!this.resource_type || !this.resource_id) return;
+    const resp = await fetch(`/webhooks/subscriptions/${this.resource_type}/${this.resource_id}`);
+    if (resp.ok) {
+      const data = await resp.json();
+      this.subscriptions = data.subscriptions || [];
+    } else {
+      alert(`Failed loading subscriptions: ${resp.status}`);
+    }
+  }
+  startEdit(sub) {
+    this.editingId = sub.id;
+    this.id = sub.id;
+    this.target_url = sub.target_url;
+    this.secret_key = sub.secret_key || "";
+  }
+  clearForm() {
+    this.editingId = null;
+    this.id = "";
+    this.target_url = "";
+    this.secret_key = "";
+  }
+  async delete(id) {
+    if (!confirm(`Delete webhook ${id}?`)) return;
+    const resp = await fetch(`/webhooks/subscriptions/delete/${encodeURIComponent(id)}`, { method: "DELETE" });
+    if (!resp.ok && resp.status !== 204) {
+      alert(`Failed deleting: ${resp.status}`);
+      return;
+    }
+    await this.load();
+    if (this.editingId === id) this.clearForm();
+  }
+  async submit(e2) {
+    e2.preventDefault();
+    if (!this.id) {
+      alert("Missing id");
+      return;
+    }
+    if (!this.target_url) {
+      alert("Missing target url");
+      return;
+    }
+    if (!this.resource_type || !this.resource_id) {
+      alert("Missing resource info");
+      return;
+    }
+    const payload = {
+      id: this.id,
+      target_url: this.target_url,
+      resource_type: this.resource_type,
+      resource_id: this.resource_id,
+      secret_key: this.secret_key ? this.secret_key : null
+    };
+    const resp = await fetch("/webhooks/subscriptions/upsert", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload)
+    });
+    if (!resp.ok) {
+      alert(`Upsert failed: ${resp.status} ${await resp.text()}`);
+      return;
+    }
+    await this.load();
+    this.editingId = this.id;
+  }
+};
+__decorateClass([
+  n()
+], EditWebhooksForm.prototype, "resource_type", 2);
+__decorateClass([
+  n()
+], EditWebhooksForm.prototype, "resource_id", 2);
+__decorateClass([
+  r()
+], EditWebhooksForm.prototype, "subscriptions", 2);
+__decorateClass([
+  r()
+], EditWebhooksForm.prototype, "editingId", 2);
+__decorateClass([
+  r()
+], EditWebhooksForm.prototype, "id", 2);
+__decorateClass([
+  r()
+], EditWebhooksForm.prototype, "target_url", 2);
+__decorateClass([
+  r()
+], EditWebhooksForm.prototype, "secret_key", 2);
+EditWebhooksForm = __decorateClass([
+  t("edit-webhooks-form")
+], EditWebhooksForm);
+export {
+  EditWebhooksForm
+};

--- a/crates/frontend/public/assets/js/edit-webhooks-form.mjs
+++ b/crates/frontend/public/assets/js/edit-webhooks-form.mjs
@@ -42,20 +42,11 @@ let EditWebhooksForm = class extends i {
     }}>Webhooks</button>
       <dialog ${n$1(this.dialog)}>
         <style>
-          form label {
-            display:block;
-            margin:.75rem 0 .25rem;
-            font-weight:600;
-          }
-          form input[type=url],
-          form input[type=text] {
-            display:block;
-            width:100%;
-            box-sizing:border-box;
-            padding:.45rem .55rem;
-            margin:0;
-          }
-          form button { margin-right:.5rem; margin-top:.75rem; }
+          form .field { margin-bottom: .85rem; }
+          form .field label { display:block; font-weight:600; margin-bottom:.35rem; }
+          form .field input[type=url],
+          form .field input[type=text] { display:block; width:100%; box-sizing:border-box; padding:.45rem .55rem; }
+          form .actions-row { margin-top:.5rem; display:flex; gap:.5rem; flex-wrap:wrap; }
         </style>
         <h3>Manage webhooks</h3>
         <div class="subscriptions">
@@ -84,19 +75,25 @@ let EditWebhooksForm = class extends i {
         <hr>
         <h4>${this.editingId ? "Edit subscription" : "Create subscription"}</h4>
         <form @submit=${this.submit} ${n$1(this.form)}>
-          <label>Target URL</label>
-          <input type="url" name="target_url" .value=${this.target_url} @input=${(e2) => this.target_url = e2.target.value} required />
-          <label>Secret (optional)</label>
-          <input type="text" name="secret_key" .value=${this.secret_key} @input=${(e2) => this.secret_key = e2.target.value} />
-          <button type="submit">${this.editingId ? "Update" : "Create"}</button>
-          <button @click=${(e2) => {
+          <div class="field">
+            <label>Target URL</label>
+            <input type="url" name="target_url" .value=${this.target_url} @input=${(e2) => this.target_url = e2.target.value} required />
+          </div>
+          <div class="field">
+            <label>Secret (optional)</label>
+            <input type="text" name="secret_key" .value=${this.secret_key} @input=${(e2) => this.secret_key = e2.target.value} />
+          </div>
+          <div class="actions-row">
+            <button type="submit">${this.editingId ? "Update" : "Create"}</button>
+            <button @click=${(e2) => {
       e2.preventDefault();
       this.clearForm();
     }} type="button">New</button>
-          <button @click=${(e2) => {
+            <button @click=${(e2) => {
       e2.preventDefault();
       this.dialog.value.close();
     }} type="button" class="cancel">Close</button>
+          </div>
         </form>
       </dialog>
     `;

--- a/crates/frontend/public/assets/js/edit-webhooks-form.mjs
+++ b/crates/frontend/public/assets/js/edit-webhooks-form.mjs
@@ -26,7 +26,6 @@ let EditWebhooksForm = class extends i {
     this.resource_id = "";
     this.subscriptions = [];
     this.editingId = null;
-    this.id = "";
     this.target_url = "";
     this.secret_key = "";
     this.dialog = e();
@@ -48,7 +47,6 @@ let EditWebhooksForm = class extends i {
           <table>
             <thead>
               <tr>
-                <th>ID</th>
                 <th>Target URL</th>
                 <th>Secret?</th>
                 <th>Actions</th>
@@ -57,7 +55,6 @@ let EditWebhooksForm = class extends i {
             <tbody>
               ${this.subscriptions.map((sub) => x`
                 <tr>
-                  <td>${sub.id}</td>
                   <td>${sub.target_url}</td>
                   <td>${sub.secret_key ? "Yes" : "No"}</td>
                   <td>
@@ -71,20 +68,16 @@ let EditWebhooksForm = class extends i {
         <hr>
         <h4>${this.editingId ? "Edit subscription" : "Create subscription"}</h4>
         <form @submit=${this.submit} ${n$1(this.form)}>
-          <label>
-            ID
-            <input type="text" name="id" .value=${this.id} ?disabled=${this.editingId !== null} @input=${(e2) => this.id = e2.target.value} required />
-          </label>
-          <br>
+          <!-- ID removed from form -->
           <label>
             Target URL
             <input type="url" name="target_url" .value=${this.target_url} @input=${(e2) => this.target_url = e2.target.value} required />
           </label>
           <br>
-          <label>
-            Secret (optional)
-            <input type="text" name="secret_key" .value=${this.secret_key} @input=${(e2) => this.secret_key = e2.target.value} />
-          </label>
+            <label>
+              Secret (optional)
+              <input type="text" name="secret_key" .value=${this.secret_key} @input=${(e2) => this.secret_key = e2.target.value} />
+            </label>
           <br>
           <button type="submit">${this.editingId ? "Update" : "Create"}</button>
           <button @click=${(e2) => {
@@ -111,13 +104,11 @@ let EditWebhooksForm = class extends i {
   }
   startEdit(sub) {
     this.editingId = sub.id;
-    this.id = sub.id;
     this.target_url = sub.target_url;
     this.secret_key = sub.secret_key || "";
   }
   clearForm() {
     this.editingId = null;
-    this.id = "";
     this.target_url = "";
     this.secret_key = "";
   }
@@ -133,10 +124,6 @@ let EditWebhooksForm = class extends i {
   }
   async submit(e2) {
     e2.preventDefault();
-    if (!this.id) {
-      alert("Missing id");
-      return;
-    }
     if (!this.target_url) {
       alert("Missing target url");
       return;
@@ -146,12 +133,12 @@ let EditWebhooksForm = class extends i {
       return;
     }
     const payload = {
-      id: this.id,
       target_url: this.target_url,
       resource_type: this.resource_type,
       resource_id: this.resource_id,
       secret_key: this.secret_key ? this.secret_key : null
     };
+    if (this.editingId) payload.id = this.editingId;
     const resp = await fetch("/webhooks/subscriptions/upsert", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -161,8 +148,9 @@ let EditWebhooksForm = class extends i {
       alert(`Upsert failed: ${resp.status} ${await resp.text()}`);
       return;
     }
+    const j = await resp.json();
+    if (!this.editingId) this.editingId = j.id;
     await this.load();
-    this.editingId = this.id;
   }
 };
 __decorateClass([
@@ -177,9 +165,6 @@ __decorateClass([
 __decorateClass([
   r()
 ], EditWebhooksForm.prototype, "editingId", 2);
-__decorateClass([
-  r()
-], EditWebhooksForm.prototype, "id", 2);
 __decorateClass([
   r()
 ], EditWebhooksForm.prototype, "target_url", 2);

--- a/crates/frontend/public/assets/js/edit-webhooks-form.mjs
+++ b/crates/frontend/public/assets/js/edit-webhooks-form.mjs
@@ -41,6 +41,22 @@ let EditWebhooksForm = class extends i {
       this.load();
     }}>Webhooks</button>
       <dialog ${n$1(this.dialog)}>
+        <style>
+          form label {
+            display:block;
+            margin:.75rem 0 .25rem;
+            font-weight:600;
+          }
+          form input[type=url],
+          form input[type=text] {
+            display:block;
+            width:100%;
+            box-sizing:border-box;
+            padding:.45rem .55rem;
+            margin:0;
+          }
+          form button { margin-right:.5rem; margin-top:.75rem; }
+        </style>
         <h3>Manage webhooks</h3>
         <div class="subscriptions">
           ${this.subscriptions.length ? x`
@@ -68,17 +84,10 @@ let EditWebhooksForm = class extends i {
         <hr>
         <h4>${this.editingId ? "Edit subscription" : "Create subscription"}</h4>
         <form @submit=${this.submit} ${n$1(this.form)}>
-          <!-- ID removed from form -->
-          <label>
-            Target URL
-            <input type="url" name="target_url" .value=${this.target_url} @input=${(e2) => this.target_url = e2.target.value} required />
-          </label>
-          <br>
-            <label>
-              Secret (optional)
-              <input type="text" name="secret_key" .value=${this.secret_key} @input=${(e2) => this.secret_key = e2.target.value} />
-            </label>
-          <br>
+          <label>Target URL</label>
+          <input type="url" name="target_url" .value=${this.target_url} @input=${(e2) => this.target_url = e2.target.value} required />
+          <label>Secret (optional)</label>
+          <input type="text" name="secret_key" .value=${this.secret_key} @input=${(e2) => this.secret_key = e2.target.value} />
           <button type="submit">${this.editingId ? "Update" : "Create"}</button>
           <button @click=${(e2) => {
       e2.preventDefault();

--- a/crates/frontend/public/assets/style.css
+++ b/crates/frontend/public/assets/style.css
@@ -287,16 +287,11 @@ ul.collection-list {
         align-items: center; /* vertically center mixed element types */
       }
 
-      .actions form { /* remove default block spacing that shifts button */
-        margin: 0;
-        display: flex;
-        align-items: center;
-      }
-
+      .actions form,
       .actions edit-calendar-form,
       .actions edit-webhooks-form,
-      .actions edit-addressbook-form,
-      .actions delete-button { /* ensure consistent inline layout */
+      .actions delete-button { /* remove default block spacing that shifts button */
+        margin: 0;
         display: flex;
         align-items: center;
       }
@@ -321,6 +316,30 @@ dialog {
 dialog::backdrop {
   background: color-mix(in srgb, var(--background-color), transparent 50%);
 }
+
+/* Explicit non-nested selectors to ensure alignment applies even without CSS nesting support */
+.inner .actions {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+.inner .actions form {
+  margin: 0;
+  display: flex;
+  align-items: center;
+}
+
+.inner .actions > * {
+  display: flex;
+  align-items: center;
+}
+
+.inner .actions button {
+  align-self: center;
+  margin: 0;
+}
+
 
 footer {
   display: flex;

--- a/crates/frontend/public/assets/style.css
+++ b/crates/frontend/public/assets/style.css
@@ -135,6 +135,7 @@ button,
 }
 
 input[type="text"],
+input[type="url"],
 input[type="password"] {
   border: 1px solid black;
   border-radius: 8px;
@@ -315,6 +316,7 @@ footer {
 }
 
 input[type="text"],
+input[type="url"],
 input[type="password"],
 input[type="color"],
 select {
@@ -335,6 +337,7 @@ form {
 
   input[type="text"],
   input[type="password"],
+  input[type="url"],
   input[type="color"],
   textarea,
   select {

--- a/crates/frontend/public/assets/style.css
+++ b/crates/frontend/public/assets/style.css
@@ -284,6 +284,21 @@ ul.collection-list {
         width: fit-content;
         display: flex;
         gap: 12px;
+        align-items: center; /* vertically center mixed element types */
+      }
+
+      .actions form { /* remove default block spacing that shifts button */
+        margin: 0;
+        display: flex;
+        align-items: center;
+      }
+
+      .actions edit-calendar-form,
+      .actions edit-webhooks-form,
+      .actions edit-addressbook-form,
+      .actions delete-button { /* ensure consistent inline layout */
+        display: flex;
+        align-items: center;
       }
     }
 

--- a/crates/frontend/public/templates/components/sections/addressbooks_section.html
+++ b/crates/frontend/public/templates/components/sections/addressbooks_section.html
@@ -22,6 +22,7 @@
           displayname="{{ addressbook.displayname.as_deref().unwrap_or_default() }}"
           description="{{ addressbook.description.as_deref().unwrap_or_default() }}"
         ></edit-addressbook-form>
+        <edit-webhooks-form resource_type="addressbook" resource_id="{{ addressbook.id }}"></edit-webhooks-form>
         <delete-button trash
           href="/carddav/principal/{{ addressbook.principal }}/{{ addressbook.id }}"></delete-button>
       </div>

--- a/crates/frontend/public/templates/components/sections/calendars_section.html
+++ b/crates/frontend/public/templates/components/sections/calendars_section.html
@@ -34,6 +34,7 @@
           color="{{ calendar.meta.color.as_deref().unwrap_or_default() }}"
           components="{{ calendar.components | json }}"
         ></edit-calendar-form>
+        <edit-webhooks-form resource_type="calendar" resource_id="{{ calendar.id }}"></edit-webhooks-form>
         <delete-button trash href="/caldav/principal/{{ calendar.principal }}/{{ calendar.id }}"></delete-button>
         {% endif %}
       </div>

--- a/crates/frontend/public/templates/pages/user.html
+++ b/crates/frontend/public/templates/pages/user.html
@@ -12,6 +12,7 @@ window.rusticalUser = JSON.parse(document.querySelector('#data-rustical-user').i
 <script type="module" src="/frontend/assets/js/edit-addressbook-form.mjs" async></script>
 <script type="module" src="/frontend/assets/js/import-addressbook-form.mjs" async></script>
 <script type="module" src="/frontend/assets/js/delete-button.mjs" async></script>
+<script type="module" src="/frontend/assets/js/edit-webhooks-form.mjs" async></script>
 {% endblock %}
 {% block header_center %}
 <nav class="header-center">

--- a/crates/store/Cargo.toml
+++ b/crates/store/Cargo.toml
@@ -25,6 +25,7 @@ tokio.workspace = true
 clap.workspace = true
 rustical_dav.workspace = true
 rustical_ical.workspace = true
+rustical_types.workspace = true
 axum.workspace = true
 http.workspace = true
 rrule.workspace = true

--- a/crates/store/src/lib.rs
+++ b/crates/store/src/lib.rs
@@ -10,6 +10,7 @@ mod combined_calendar_store;
 mod contact_birthday_store;
 mod secret;
 mod subscription_store;
+mod webhook_subscription_store;
 pub mod synctoken;
 
 #[cfg(test)]
@@ -21,7 +22,7 @@ pub use combined_calendar_store::CombinedCalendarStore;
 pub use contact_birthday_store::ContactBirthdayStore;
 pub use secret::Secret;
 pub use subscription_store::*;
-
+pub use webhook_subscription_store::*;
 pub use addressbook::Addressbook;
 pub use calendar::{Calendar, CalendarMetadata};
 

--- a/crates/store/src/webhook_subscription_store.rs
+++ b/crates/store/src/webhook_subscription_store.rs
@@ -1,0 +1,12 @@
+use crate::Error;
+use async_trait::async_trait;
+use rustical_types::WebhookSubscription;
+
+#[async_trait]
+pub trait WebhookSubscriptionStore: Send + Sync + 'static {
+    async fn get_subscriptions(&self, resource_type: &str, resource_id: &str) -> Result<Vec<WebhookSubscription>, Error>;
+    async fn get_subscription(&self, id: &str) -> Result<WebhookSubscription, Error>;
+    /// Returns whether a subscription under the id already existed
+    async fn upsert_subscription(&self, sub: WebhookSubscription) -> Result<bool, Error>;
+    async fn delete_subscription(&self, id: &str) -> Result<(), Error>;
+}

--- a/crates/store_sqlite/Cargo.toml
+++ b/crates/store_sqlite/Cargo.toml
@@ -29,4 +29,5 @@ password-hash.workspace = true
 uuid.workspace = true
 pbkdf2.workspace = true
 rustical_ical.workspace = true
+rustical_types.workspace = true
 rstest = { workspace = true, optional = true }

--- a/crates/store_sqlite/migrations/20251123171144_webhooks.sql
+++ b/crates/store_sqlite/migrations/20251123171144_webhooks.sql
@@ -1,0 +1,8 @@
+CREATE TABLE webhook_subscriptions (
+    id TEXT NOT NULL,
+    target_url TEXT NOT NULL,
+    resource_type TEXT NOT NULL,
+    resource_id TEXT NOT NULL,
+    secret_key TEXT,
+    PRIMARY KEY (id)
+);

--- a/crates/store_sqlite/src/lib.rs
+++ b/crates/store_sqlite/src/lib.rs
@@ -9,6 +9,7 @@ pub mod calendar_store;
 pub mod error;
 pub mod principal_store;
 pub mod subscription_store;
+pub mod webhook_subscription_store;
 
 // Begin statement for write transactions
 pub const BEGIN_IMMEDIATE: &str = "BEGIN IMMEDIATE";

--- a/crates/store_sqlite/src/tests/mod.rs
+++ b/crates/store_sqlite/src/tests/mod.rs
@@ -41,12 +41,14 @@ async fn get_test_db() -> SqlitePool {
 #[rstest::fixture]
 pub async fn get_test_addressbook_store() -> SqliteAddressbookStore {
     let (send, _recv) = tokio::sync::mpsc::channel(1000);
-    SqliteAddressbookStore::new(get_test_db().await, send)
+    let (whsend, _recv) = tokio::sync::mpsc::channel(1000);
+    SqliteAddressbookStore::new(get_test_db().await, send, whsend)
 }
 #[rstest::fixture]
 pub async fn get_test_calendar_store() -> SqliteCalendarStore {
     let (send, _recv) = tokio::sync::mpsc::channel(1000);
-    SqliteCalendarStore::new(get_test_db().await, send)
+    let (whsend, _recv) = tokio::sync::mpsc::channel(1000);
+    SqliteCalendarStore::new(get_test_db().await, send, whsend)
 }
 #[rstest::fixture]
 pub async fn get_test_subscription_store() -> SqliteStore {

--- a/crates/store_sqlite/src/webhook_subscription_store.rs
+++ b/crates/store_sqlite/src/webhook_subscription_store.rs
@@ -1,0 +1,60 @@
+use crate::SqliteStore;
+use async_trait::async_trait;
+use rustical_store::{Error, WebhookSubscriptionStore};
+use rustical_types::WebhookSubscription;
+
+#[async_trait]
+impl WebhookSubscriptionStore for SqliteStore {
+    async fn get_subscriptions(&self, resource_type: &str, resource_id: &str) -> Result<Vec<WebhookSubscription>, Error>{
+        Ok(sqlx::query_as!(
+            WebhookSubscription,
+            r#"SELECT id, target_url, resource_type, resource_id, secret_key
+                FROM webhook_subscriptions
+                WHERE (resource_type = ? AND resource_id = ?)"#,
+            resource_type,
+            resource_id
+        )
+        .fetch_all(&self.db)
+        .await
+        .map_err(crate::Error::from)?)
+    }
+
+    async fn get_subscription(&self, id: &str) -> Result<WebhookSubscription, Error>{
+        Ok(sqlx::query_as!(
+            WebhookSubscription,
+            r#"SELECT id, target_url, resource_type, resource_id, secret_key
+                FROM webhook_subscriptions
+                WHERE (id) = (?)"#,
+            id
+        )
+        .fetch_one(&self.db)
+        .await
+        .map_err(crate::Error::from)?)
+    }
+    
+    // Returns whether a subscription under the id already existed
+    async fn upsert_subscription(&self, sub: WebhookSubscription) -> Result<bool, Error>{
+        let already_exists = match self.get_subscription(&sub.id).await {
+            Ok(_) => true,
+            Err(Error::NotFound) => false,
+            Err(err) => return Err(err),
+        };
+        sqlx::query!(
+            r#"INSERT OR REPLACE INTO webhook_subscriptions (id, target_url, resource_type, resource_id, secret_key) VALUES (?, ?, ?, ?, ?)"#,
+            sub.id,
+            sub.target_url,
+            sub.resource_type,
+            sub.resource_id,
+            sub.secret_key
+        ).execute(&self.db).await.map_err(crate::Error::from)?;
+        Ok(already_exists)
+    }
+    
+    async fn delete_subscription(&self, id: &str) -> Result<(), Error>{
+        sqlx::query!(
+            r#"DELETE FROM webhook_subscriptions WHERE id = ?"#,
+            id
+        ).execute(&self.db).await.map_err(crate::Error::from)?;
+        Ok(())
+    }
+}

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "rustical_types"
+version.workspace = true
+rust-version.workspace = true
+edition.workspace = true
+description.workspace = true
+repository.workspace = true
+license.workspace = true
+publish = false
+
+[dependencies]
+serde_json.workspace = true

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -10,3 +10,4 @@ publish = false
 
 [dependencies]
 serde_json.workspace = true
+serde.workspace = true

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -1,0 +1,3 @@
+mod webhook_types;
+
+pub use webhook_types::*;

--- a/crates/types/src/webhook_types.rs
+++ b/crates/types/src/webhook_types.rs
@@ -1,4 +1,5 @@
 use serde_json::{json, Value};
+use serde::{Serialize, Deserialize};
 
 #[derive(Debug)]
 pub enum WebhookEvent {
@@ -36,7 +37,7 @@ pub enum WebhookEvent {
     },
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct WebhookSubscription {
     pub id: String,
     pub resource_type: String,

--- a/crates/types/src/webhook_types.rs
+++ b/crates/types/src/webhook_types.rs
@@ -1,0 +1,184 @@
+use serde_json::{json, Value};
+
+#[derive(Debug)]
+pub enum WebhookEvent {
+    CalendarObjectUpsert {
+        resource_id: String,
+        object_uid: String,
+        timestamp: i64, 
+        ics_data: String, // full ICS data
+    },
+    CalendarObjectDelete {
+        resource_id: String,
+        object_uid: String,
+        timestamp: i64
+    },
+    CalendarObjectRestore {
+        resource_id: String,
+        object_uid: String,
+        timestamp: i64
+    },
+    AddressbookObjectUpsert {
+        resource_id: String,
+        object_uid: String,
+        timestamp: i64, 
+        vcf_data: String, // full VCF data
+    },
+    AddressbookObjectDelete {
+        resource_id: String,
+        object_uid: String,
+        timestamp: i64
+    },
+    AddressbookObjectRestore {
+        resource_id: String,
+        object_uid: String,
+        timestamp: i64
+    },
+}
+
+#[derive(Debug)]
+pub struct WebhookSubscription {
+    pub id: String,
+    pub resource_type: String,
+    pub resource_id: String,
+    pub target_url: String,
+    pub secret_key: Option<String>,
+}
+
+
+impl WebhookEvent {
+    pub fn event_type(&self) -> &str {
+        match self {
+            WebhookEvent::CalendarObjectUpsert { .. } => "Upsert",
+            WebhookEvent::CalendarObjectDelete { .. } => "Delete",
+            WebhookEvent::CalendarObjectRestore { .. } => "Restore",
+            WebhookEvent::AddressbookObjectUpsert { .. } => "Upsert",
+            WebhookEvent::AddressbookObjectDelete { .. } => "Delete",
+            WebhookEvent::AddressbookObjectRestore { .. } => "Restore",
+        }
+    }
+
+    /// Build the webhook JSON payload with all required fields
+    pub fn to_payload_json(&self) -> Value {
+        match self {
+            WebhookEvent::CalendarObjectUpsert { resource_id, object_uid, timestamp, ics_data } => {
+                json!({
+                    "event_type": self.event_type(),
+                    "resource_type": self.resource_type(),
+                    "resource_id": resource_id,
+                    "object_uid": object_uid,
+                    "timestamp": timestamp,
+                    "ics_data": ics_data
+                })
+            }
+            WebhookEvent::CalendarObjectDelete { resource_id, object_uid, timestamp } => {
+                json!({
+                    "event_type": self.event_type(),
+                    "resource_type": self.resource_type(),
+                    "resource_id": resource_id,
+                    "object_uid": object_uid,
+                    "timestamp": timestamp
+                })
+            }
+            WebhookEvent::CalendarObjectRestore { resource_id, object_uid, timestamp } => {
+                json!({
+                    "event_type": self.event_type(),
+                    "resource_type": self.resource_type(),
+                    "resource_id": resource_id,
+                    "object_uid": object_uid,
+                    "timestamp": timestamp
+                })
+            }
+            WebhookEvent::AddressbookObjectUpsert { resource_id, object_uid, timestamp, vcf_data } => {
+                json!({
+                    "event_type": self.event_type(),
+                    "resource_type": self.resource_type(),
+                    "resource_id": resource_id,
+                    "object_uid": object_uid,
+                    "timestamp": timestamp,
+                    "vcf_data": vcf_data
+                })
+            }
+            WebhookEvent::AddressbookObjectDelete { resource_id, object_uid, timestamp } => {
+                json!({
+                    "event_type": self.event_type(),
+                    "resource_type": self.resource_type(),
+                    "resource_id": resource_id,
+                    "object_uid": object_uid,
+                    "timestamp": timestamp
+                })
+            }
+            WebhookEvent::AddressbookObjectRestore { resource_id, object_uid, timestamp } => {
+                json!({
+                    "event_type": self.event_type(),
+                    "resource_type": self.resource_type(),
+                    "resource_id": resource_id,
+                    "object_uid": object_uid,
+                    "timestamp": timestamp
+                })
+            }
+        }
+    }
+
+    pub fn resource_type(&self) -> &'static str {
+        match self {
+            WebhookEvent::CalendarObjectUpsert { .. } => "calendar",
+            WebhookEvent::CalendarObjectDelete { .. } => "calendar",
+            WebhookEvent::CalendarObjectRestore { .. } => "calendar",
+            WebhookEvent::AddressbookObjectUpsert { .. } => "addressbook",
+            WebhookEvent::AddressbookObjectDelete { .. } => "addressbook",
+            WebhookEvent::AddressbookObjectRestore { .. } => "addressbook",
+        }
+    }
+
+    pub fn resource_id(&self) -> &str {
+        match self {
+            WebhookEvent::CalendarObjectUpsert { resource_id, .. } =>
+                resource_id,
+            WebhookEvent::CalendarObjectDelete { resource_id, .. } =>
+                resource_id,
+            WebhookEvent::CalendarObjectRestore { resource_id, .. } =>
+                resource_id,
+            WebhookEvent::AddressbookObjectUpsert { resource_id, .. } =>
+                resource_id,
+            WebhookEvent::AddressbookObjectDelete { resource_id, .. } =>
+                resource_id,
+            WebhookEvent::AddressbookObjectRestore { resource_id, .. } =>
+                resource_id,
+        }
+    }
+
+    pub fn object_uid(&self) -> &str {
+        match self {
+            WebhookEvent::CalendarObjectUpsert { object_uid, .. } =>
+                object_uid,
+            WebhookEvent::CalendarObjectDelete { object_uid, .. } =>
+                object_uid,
+            WebhookEvent::CalendarObjectRestore { object_uid, .. } =>
+                object_uid,
+            WebhookEvent::AddressbookObjectUpsert { object_uid, .. } =>
+                object_uid,
+            WebhookEvent::AddressbookObjectDelete { object_uid, .. } =>
+                object_uid,
+            WebhookEvent::AddressbookObjectRestore { object_uid, .. } =>
+                object_uid,
+        }
+    }
+
+    pub fn timestamp(&self) -> i64 {
+        match self {
+            WebhookEvent::CalendarObjectUpsert { timestamp, .. } =>
+                *timestamp,
+            WebhookEvent::CalendarObjectDelete { timestamp, .. } =>
+                *timestamp,
+            WebhookEvent::CalendarObjectRestore { timestamp, .. } =>
+                *timestamp,
+            WebhookEvent::AddressbookObjectUpsert { timestamp, .. } =>
+                *timestamp,
+            WebhookEvent::AddressbookObjectDelete { timestamp, .. } =>
+                *timestamp,
+            WebhookEvent::AddressbookObjectRestore { timestamp, .. } =>
+                *timestamp,
+        }
+    }
+}

--- a/crates/webhooks/Cargo.toml
+++ b/crates/webhooks/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "rustical_webhooks"
+version.workspace = true
+rust-version.workspace = true
+edition.workspace = true
+description.workspace = true
+repository.workspace = true
+license.workspace = true
+publish = false
+
+
+[dependencies]
+serde_json.workspace = true
+serde.workspace = true
+rustical_ical.workspace = true
+rustical_store.workspace = true
+tokio.workspace = true
+hmac = "0.12.1"
+sha2.workspace = true
+base64.workspace = true
+axum.workspace = true
+http.workspace = true
+reqwest.workspace = true
+rustical_types.workspace = true

--- a/crates/webhooks/Cargo.toml
+++ b/crates/webhooks/Cargo.toml
@@ -22,3 +22,4 @@ axum.workspace = true
 http.workspace = true
 reqwest.workspace = true
 rustical_types.workspace = true
+uuid.workspace = true

--- a/crates/webhooks/src/controller.rs
+++ b/crates/webhooks/src/controller.rs
@@ -1,0 +1,113 @@
+use tokio::sync::mpsc::Receiver;
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
+use base64::{engine::general_purpose, Engine as _};
+use std::{sync::Arc, time::Duration};
+use tokio::time::sleep;
+use rustical_types::WebhookEvent;
+
+// Assume WebhookStore is defined elsewhere and provides endpoint lookup
+use rustical_store::WebhookSubscriptionStore;
+
+/// Controller that receives WebhookEvents and processes them
+pub struct WebhookController<S: WebhookSubscriptionStore> {
+	receiver: Receiver<WebhookEvent>,
+	store: Arc<S>,
+}
+
+struct RetryItem {
+	endpoint: String,
+	payload: String,
+	attempts: u32,
+	max_attempts: u32,
+	backoff: Duration,
+}
+
+type HmacSha256 = Hmac<Sha256>;
+
+fn sign_payload(payload: &str, secret: &str) -> String {
+	let mut mac = HmacSha256::new_from_slice(secret.as_bytes()).expect("HMAC can take key of any size");
+	mac.update(payload.as_bytes());
+	let result = mac.finalize().into_bytes();
+	general_purpose::STANDARD.encode(result)
+}
+
+impl<S: WebhookSubscriptionStore> WebhookController<S> {
+	pub fn new(receiver: Receiver<WebhookEvent>, store: Arc<S>) -> Self {
+		Self { receiver, store }
+	}
+
+	/// Start processing events (to be expanded with dispatch, retry, etc.)
+	pub async fn run(mut self) {
+
+		while let Some(event) = self.receiver.recv().await {
+			let subscriptions = match self
+                .store
+                .get_subscriptions(&event.resource_type(), &event.resource_id())
+                .await
+            {
+                Ok(list) => list,
+                Err(err) => {
+                    eprintln!("Failed to load subscriptions: {:?}", err);
+                    vec![]
+                }
+            };
+			println!("Received event: {:?}", event);
+			println!("Found subscribers: {:?}", subscriptions);
+			let payload = event.to_payload_json();
+            
+			for subscription in subscriptions {
+				let mut signature = None;
+				if let Some(secret) = &subscription.secret_key {
+					signature = Some(sign_payload(&payload.to_string(), secret));
+					println!("Signing payload for {} with secret", subscription.target_url);
+				}
+				let endpoint = subscription.target_url.clone();
+				let payload_str = payload.to_string();
+				let max_attempts = 5;
+				let initial_backoff = Duration::from_secs(2);
+				let retry_item = RetryItem {
+					endpoint: endpoint.clone(),
+					payload: payload_str.clone(),
+					attempts: 0,
+					max_attempts,
+					backoff: initial_backoff,
+				};
+				tokio::spawn(Self::send_with_retry(retry_item, signature));
+			}
+		}
+        
+	}
+
+	async fn send_with_retry(mut item: RetryItem, signature: Option<String>) {
+		let client = reqwest::Client::new();
+		loop {
+			let mut req = client.post(&item.endpoint)
+				.header("Content-Type", "application/json");
+			if let Some(sig) = &signature {
+				req = req.header("X-Signature", sig);
+			}
+			let res = req.body(item.payload.clone()).send().await;
+			match res {
+				Ok(resp) if resp.status().is_success() => {
+					println!("Webhook delivered to {}", item.endpoint);
+					break;
+				}
+				Ok(resp) => {
+					println!("Webhook delivery failed to {}: {}", item.endpoint, resp.status());
+				}
+				Err(e) => {
+					println!("Webhook delivery error to {}: {}", item.endpoint, e);
+				}
+			}
+			item.attempts += 1;
+			if item.attempts >= item.max_attempts {
+				println!("Max retry attempts reached for {}", item.endpoint);
+				break;
+			}
+			println!("Retrying {} in {:?} (attempt {})", item.endpoint, item.backoff, item.attempts);
+			sleep(item.backoff).await;
+			item.backoff *= 2;
+		}
+	}
+}

--- a/crates/webhooks/src/endpoints.rs
+++ b/crates/webhooks/src/endpoints.rs
@@ -75,8 +75,8 @@ async fn handle_list<S: WebhookSubscriptionStore>(
 pub fn webhook_subscription_router<S: WebhookSubscriptionStore>(store: Arc<S>) -> Router {
     Router::new()
         .route("/webhooks/subscriptions/upsert", post(handle_upsert::<S>))
-        .route("/webhooks/subscriptions/delete/:id", delete(handle_delete::<S>))
-        .route("/webhooks/subscriptions/id/:id", get(handle_get::<S>))
-        .route("/webhooks/subscriptions/:resource_type/:resource_id", get(handle_list::<S>))
+        .route("/webhooks/subscriptions/delete/{id}", delete(handle_delete::<S>))
+        .route("/webhooks/subscriptions/id/{id}", get(handle_get::<S>))
+        .route("/webhooks/subscriptions/{resource_type}/{resource_id}", get(handle_list::<S>))
         .with_state(store)
 }

--- a/crates/webhooks/src/endpoints.rs
+++ b/crates/webhooks/src/endpoints.rs
@@ -1,0 +1,64 @@
+use axum::{
+    Router,
+    extract::{Path, State},
+    response::{IntoResponse, Response},
+    routing::{delete, post},
+};
+use http::StatusCode;
+use rustical_store::{ WebhookSubscriptionStore};
+use std::sync::Arc;
+use serde_json::json;
+use serde::Deserialize;
+use axum::extract::Json;
+use rustical_types::WebhookSubscription;
+
+async fn handle_delete<S: WebhookSubscriptionStore>(
+    State(store): State<Arc<S>>,
+    Path(id): Path<String>,
+) -> Result<Response, rustical_store::Error> {
+    store.delete_subscription(&id).await?;
+    Ok((StatusCode::NO_CONTENT, "Unregistered").into_response())
+}
+
+
+#[derive(Deserialize)]
+struct UpsertPayload {
+    id: String,
+    target_url: String,
+    resource_type: String,
+    resource_id: String,
+    secret_key: Option<String>,
+}
+
+async fn handle_upsert<S: WebhookSubscriptionStore>(
+    State(store): State<Arc<S>>,
+    Json(payload): Json<UpsertPayload>,
+) -> Result<Response, rustical_store::Error> {
+
+    let subscription = WebhookSubscription {
+        id: payload.id,
+        target_url: payload.target_url,
+        resource_type: payload.resource_type,
+        resource_id: payload.resource_id,
+        secret_key: payload.secret_key,
+    };
+
+    let id = subscription.id.clone(); 
+
+    let already_exists = store.upsert_subscription(subscription).await?;
+    let status = if already_exists { StatusCode::OK } else { StatusCode::CREATED };
+    let body = json!({
+        "id": id,
+        "updated": already_exists,
+        "status": if already_exists { "updated" } else { "created" }
+    });
+    Ok((status, Json(body)).into_response())
+}
+
+// public function to create the webhook subscription router
+pub fn webhook_subscription_router<S: WebhookSubscriptionStore>(store: Arc<S>) -> Router {
+    Router::new()
+        .route("/webhooks/subscriptions/upsert", post(handle_upsert::<S>))
+        .route("/webhooks/subscriptions/delete/:id", delete(handle_delete::<S>))
+        .with_state(store)
+}

--- a/crates/webhooks/src/lib.rs
+++ b/crates/webhooks/src/lib.rs
@@ -1,0 +1,4 @@
+pub mod controller;
+
+mod endpoints;
+pub use endpoints::webhook_subscription_router;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,6 +1,6 @@
 use crate::config::{
     Config, DataStoreConfig, DavPushConfig, HttpConfig, NextcloudLoginConfig,
-    SqliteDataStoreConfig, TracingConfig,
+    SqliteDataStoreConfig, TracingConfig, WebhookConfig,
 };
 use clap::Parser;
 use rustical_frontend::FrontendConfig;
@@ -25,6 +25,7 @@ pub fn cmd_gen_config(_args: GenConfigArgs) -> anyhow::Result<()> {
         },
         oidc: None,
         dav_push: DavPushConfig::default(),
+        webhook: WebhookConfig::default(),
         nextcloud_login: NextcloudLoginConfig::default(),
     };
     let generated_config = toml::to_string(&config)?;

--- a/src/commands/principals.rs
+++ b/src/commands/principals.rs
@@ -64,7 +64,7 @@ pub async fn cmd_principals(args: PrincipalsArgs) -> anyhow::Result<()> {
         .merge(Env::prefixed("RUSTICAL_").split("__"))
         .extract()?;
 
-    let (_, _, _, principal_store, _) = get_data_stores(true, &config.data_store).await?;
+    let (_, _, _, _, principal_store, _, _) = get_data_stores(true, &config.data_store).await?;
 
     match args.command {
         Command::List => {

--- a/src/config.rs
+++ b/src/config.rs
@@ -64,6 +64,20 @@ impl Default for DavPushConfig {
         }
     }
 }
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields, default)]
+pub struct WebhookConfig {
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+}
+
+impl Default for WebhookConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+        }
+    }
+}
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(deny_unknown_fields, default)]
@@ -91,6 +105,8 @@ pub struct Config {
     pub tracing: TracingConfig,
     #[serde(default)]
     pub dav_push: DavPushConfig,
+    #[serde(default)]
+    pub webhook: WebhookConfig,
     #[serde(default)]
     pub nextcloud_login: NextcloudLoginConfig,
 }


### PR DESCRIPTION
Features:
- create webhooks via the UI (using a url and an option key) for calendars/addressbooks you have access to
- delete and edit via the UI existing webhooks for calendars/addressbooks you have access to
- save webhook subscriptions to the sqlite database
- disable webhooks via config [TODO: hide webhook button if webhooks are disabled]
- trigger webhooks on calendar/addressbook object put/delete/restore
- send webhooks (with HMAC signing if secret key is provided)
- retry send on bad response, up to 5 times

Current schema of the webhook is very simple, providing the following:
- resource_type (calendar | addressbook)
- resource_id
- event_type
- object_uid
- timestamp
- If not delete/restore event: ics_data (for calendar) or vcf_data (for addressbook)