### PR TITLE
Allow OIDC email as user ID

### DIFF
--- a/crates/oidc/src/config.rs
+++ b/crates/oidc/src/config.rs
@@ -9,6 +9,8 @@ pub enum UserIdClaim {
     // The more ergonomic option if you know what you're doing
     #[default]
     PreferredUsername,
+    // The hopefully unique option
+    Email,
 }
 
 #[derive(Deserialize, Serialize, Clone)]

--- a/crates/oidc/src/lib.rs
+++ b/crates/oidc/src/lib.rs
@@ -219,6 +219,10 @@ pub async fn route_get_oidc_callback<US: UserStore + Clone>(
             .preferred_username()
             .ok_or(OidcError::Other("Missing preferred_username claim"))?
             .to_string(),
+        UserIdClaim::Email => user_info_claims
+            .email()
+            .ok_or(OidcError::Other("Missing email claim"))?
+            .to_string(),
     };
 
     match user_store.user_exists(&user_id).await {

--- a/docs/setup/oidc.md
+++ b/docs/setup/oidc.md
@@ -19,7 +19,7 @@ allow_sign_up = true
 allow_password_login = false  # optional
 ```
 
-1. Can be either `preferred_username` or `sub`
+1. Can be `preferred_username`, `email` or `sub`
 2. Optional: You can require a user to be in a certain group to use RustiCal
 
 ```yaml title="Authelia configuration"


### PR DESCRIPTION
This is the "better" alternative to `preferred_username` for example for TSIDP, since that one isn't guaranteed to be unique (see https://github.com/tailscale/tsidp/blob/4c2b5ae3c82a0cadc0fce7625a6bb0308cc54e42/server/token.go#L65)
