### PR TITLE
OIDC: allow additional audiences

### DIFF
--- a/crates/oidc/src/config.rs
+++ b/crates/oidc/src/config.rs
@@ -27,5 +27,5 @@ pub struct OidcConfig {
     #[serde(default)]
     pub claim_userid: UserIdClaim,
     #[serde(default)]
-    pub additional_audience: Vec<Audience>,
+    pub additional_audiences: Vec<Audience>,
 }

--- a/crates/oidc/src/lib.rs
+++ b/crates/oidc/src/lib.rs
@@ -186,7 +186,7 @@ pub async fn route_get_oidc_callback<US: UserStore + Clone>(
         .map_err(|_| OidcError::Other("Error requesting token"))?;
     let id_token_verifier = &oidc_client
         .id_token_verifier()
-        .set_other_audience_verifier_fn(|f| oidc_config.additional_audience.iter().any(|g| f == g));
+        .set_other_audience_verifier_fn(|aud| oidc_config.additional_audiences.contains(aud));
     let id_claims = token_response
         .id_token()
         .ok_or(OidcError::Other("OIDC provider did not return an ID token"))?


### PR DESCRIPTION
OIDC clients have to reject the id-token if any audience is listed at the `aud` field they do not explicitly trust. This cause that you can currently not use rustical with any OIDC server which add additional audiences to this field. For example I can not deploy rustical together with zitadel sso, since zitadell also use the project id as an additional audience. This PR add the option to define additional audiences.

see https://openid.net/specs/openid-connect-core-1_0.html#IDTokenValidation

The openidconnect crate seems to be one of the few OIDC clients, which actual check the `aud` field. (At least i was able to deploy multiple other project without adding additional audiences.). Hit the same issue on my private project using the same crate.