### PR TITLE
OIDC: allow numeric client ids

### DIFF
--- a/crates/oidc/src/config.rs
+++ b/crates/oidc/src/config.rs
@@ -37,6 +37,8 @@ impl UserIdClaim {
     }
 }
 
+/// Deserialize a `ClientId` from either string or integer input.
+/// Identity providers like Zitadel generate numeric client ids which would otherwise need to be quoted as `RUSTICAL_OIDC__CLIENT_ID="\"123\""` which may be counterintuitive
 fn deserialize_client_id<'de, D>(deserializer: D) -> Result<ClientId, D::Error>
 where
     D: Deserializer<'de>,


### PR DESCRIPTION
Serde strictly enforces type checking during deserialization, meaning a field defined as a string will completely reject an unquoted integer. This causes an issue where you currently cannot easily use rustical with any OIDC server that generates purely numeric client IDs.

For example, I can't deploy rustical with zitadel without wrapping the environment variable in escaped literal quotes, since zitadel uses purely numeric Snowflake IDs.

This PR uses the `serde-aux` crate to allow numeric client IDs in the configuration by parsing them as strings, while completely preserving the existing ability to handle standard string IDs.