### PR TITLE
Use configurable UID/GID with a non-root default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,11 @@ COPY . .
 RUN cargo install --locked --target "$(cat /tmp/rust_target)" --path .
 
 FROM scratch
+
+ARG UID=65534
+ARG GID=65534
+USER $UID:$GID
+
 COPY --from=builder /usr/local/cargo/bin/rustical /usr/local/bin/rustical
 CMD ["/usr/local/bin/rustical"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,19 +38,20 @@ RUN cargo chef cook --release --target "$(cat /tmp/rust_target)"
 COPY . .
 RUN cargo install --locked --target "$(cat /tmp/rust_target)" --path .
 
-FROM scratch
+FROM alpine
 
-ARG UID=65534
-ARG GID=65534
-USER $UID:$GID
+RUN apk add --no-cache su-exec
 
 COPY --from=builder /usr/local/cargo/bin/rustical /usr/local/bin/rustical
-CMD ["/usr/local/bin/rustical"]
+COPY --chmod=755 entrypoint.sh /entrypoint.sh
 
 ENV RUSTICAL_DATA_STORE__SQLITE__DB_URL=/var/lib/rustical/db.sqlite3
 
 LABEL org.opencontainers.image.authors="Lennart Kämmle github.com/lennart-k"
 LABEL org.opencontainers.image.licenses="AGPL-3.0-or-later"
 EXPOSE 4000
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["/usr/local/bin/rustical"]
 
 HEALTHCHECK --interval=30s --timeout=30s --start-period=3s --retries=3 CMD ["/usr/local/bin/rustical", "health"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+PUID=${PUID:-1000}
+PGID=${PGID:-1000}
+
+if [ "$(id -u)" -ne 0 ]; then
+    exec "$@"
+fi
+
+if ! getent group rustical > /dev/null 2>&1; then
+    addgroup -g "$PGID" rustical
+fi
+
+if ! id rustical > /dev/null 2>&1; then
+    if ! getent passwd "$PUID" > /dev/null 2>&1; then
+        adduser -D -u "$PUID" -G rustical rustical
+    fi
+fi
+
+mkdir -p /var/lib/rustical
+find /var/lib/rustical \( ! -user "$PUID" -o ! -group "$PGID" \) -exec chown "${PUID}:${PGID}" {} +
+
+exec su-exec "$PUID:$PGID" "$@"


### PR DESCRIPTION
Make it possible to run the docker container as a non-root user, defaulting to 65534, the conventional nobody user.