### PR TITLE
docs: Update NixOS install section

### DIFF
--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -55,19 +55,27 @@ cargo install --locked --git https://github.com/lennart-k/rustical
     The NixOS package is not maintained by myself but since I appreciate [@PopeRigby](https://github.com/PopeRigby)'s work on it I want to mention it.
     Since rustical's development is still quite active I **strongly** recommend installing from the `nixpkgs-unstable` branch.
 
-In the `nixpkgs-unstable` you'll find a `rustical` package you can install.
-
-There's also a service that has not been merged yet. If you know how to add modules from PRs in Nix
-you can already install it <https://github.com/NixOS/nixpkgs/pull/424188>
-and then setup rustical as a service:
+NixOS 26.05 ships with Rustical and provides a module to set it up as a systemd service.
 
 ```nix title="In your configuration.nix"
-services.rustical = {
+{
+  services.rustical = {
     enable = true;
-    package = inputs.rustical.legacyPackages.${pkgs.stdenv.hostPlatform.system}.rustical;
     settings = {
-        # Settings the same as in config.toml but in Nix syntax
-        # http.port = 3002;
+      # Settings the same as in config.toml but in Nix syntax
+      # http.port = 3002;
     };
-};
+  };
+
+  security.acme.acceptTerms = true;
+
+  services.nginx.virtualHosts."rustical.example.com" = {
+    enableACME = true;
+    forceSSL = true;
+
+    locations."/" = {
+      proxyPass = with config.services.rustical.settings.http; "http://${host}:${toString port}";
+    };
+  };
+}
 ```


### PR DESCRIPTION
With the module merged we can remove the PR hint. At the same time since Rustical recommends HTTPS we provide an example with nginx as a reverse-proxy.