### PR TITLE
fix: Make sure `REPORT` works correctly with email-based principals.

### DIFF
--- a/crates/caldav/src/calendar/methods/report/calendar_multiget.rs
+++ b/crates/caldav/src/calendar/methods/report/calendar_multiget.rs
@@ -26,8 +26,8 @@ pub async fn get_objects_calendar_multiget<C: CalendarStore>(
     let mut not_found = vec![];
 
     for href in &cal_query.href {
-        if let Ok(href) = percent_encoding::percent_decode_str(href).decode_utf8()
-            && let Some(filename) = href.strip_prefix(path)
+        if let Some(stripped) = href.strip_prefix(path)
+            && let Ok(filename) = percent_encoding::percent_decode_str(stripped).decode_utf8()
         {
             let filename = filename.trim_start_matches('/');
             if let Some(object_id) = filename.strip_suffix(".ics") {

--- a/crates/caldav/src/calendar/methods/report/calendar_multiget.rs
+++ b/crates/caldav/src/calendar/methods/report/calendar_multiget.rs
@@ -33,11 +33,11 @@ pub async fn get_objects_calendar_multiget<C: CalendarStore>(
             if let Some(object_id) = filename.strip_suffix(".ics") {
                 match store.get_object(principal, cal_id, object_id, false).await {
                     Ok(object) => result.push((object_id.to_owned(), object)),
-                    Err(rustical_store::Error::NotFound) => not_found.push(href.to_string()),
+                    Err(rustical_store::Error::NotFound) => not_found.push(href.clone()),
                     Err(err) => return Err(err.into()),
                 }
             } else {
-                not_found.push(href.to_string());
+                not_found.push(href.clone());
             }
         } else {
             not_found.push(href.to_owned());

--- a/crates/carddav/src/addressbook/methods/report/addressbook_multiget.rs
+++ b/crates/carddav/src/addressbook/methods/report/addressbook_multiget.rs
@@ -34,8 +34,8 @@ pub async fn get_objects_addressbook_multiget<AS: AddressbookStore>(
     let mut not_found = vec![];
 
     for href in &addressbook_multiget.href {
-        if let Ok(href) = percent_encoding::percent_decode_str(href).decode_utf8()
-            && let Some(filename) = href.strip_prefix(path)
+        if let Some(filename) = href.strip_prefix(path)
+            && let Ok(href) = percent_encoding::percent_decode_str(href).decode_utf8()
         {
             let filename = filename.trim_start_matches('/');
             if let Some(object_id) = filename.strip_suffix(".vcf") {

--- a/tests/integration_tests/caldav/calendar_report.rs
+++ b/tests/integration_tests/caldav/calendar_report.rs
@@ -4,8 +4,8 @@ use axum::extract::Request;
 use headers::{Authorization, HeaderMapExt};
 use http::StatusCode;
 use rstest::rstest;
-use rustical_store_sqlite::tests::{TestStoreContext, test_store_context};
 use rustical_store::auth::{AuthenticationProvider, Principal, PrincipalType};
+use rustical_store_sqlite::tests::{TestStoreContext, test_store_context};
 use tower::ServiceExt;
 
 const ICS_1: &str = include_str!("resources/rfc4791_appb.ics");

--- a/tests/integration_tests/caldav/calendar_report.rs
+++ b/tests/integration_tests/caldav/calendar_report.rs
@@ -5,6 +5,7 @@ use headers::{Authorization, HeaderMapExt};
 use http::StatusCode;
 use rstest::rstest;
 use rustical_store_sqlite::tests::{TestStoreContext, test_store_context};
+use rustical_store::auth::{AuthenticationProvider, Principal, PrincipalType};
 use tower::ServiceExt;
 
 const ICS_1: &str = include_str!("resources/rfc4791_appb.ics");
@@ -206,4 +207,80 @@ async fn test_report(
     if let Some(output) = output {
         similar_asserts::assert_eq!(output, body.replace('\r', ""));
     }
+}
+
+const REPORT_EMAIL_PRINCIPAL: &str = r#"
+ <?xml version="1.0" encoding="utf-8" ?>
+   <C:calendar-multiget xmlns:D="DAV:"
+                        xmlns:C="urn:ietf:params:xml:ns:caldav">
+     <D:prop>
+       <C:calendar-data/>
+     </D:prop>
+     <D:href>/caldav/principal/cyrus%40example.com/calendar/abcd3.ics</D:href>
+   </C:calendar-multiget>
+"#;
+#[rstest]
+#[case(0, ICS_1, REPORT_EMAIL_PRINCIPAL)]
+#[tokio::test]
+async fn test_report_email_principal(
+    #[from(test_store_context)]
+    #[future]
+    context: TestStoreContext,
+    #[case] case: usize,
+    #[case] ics: &'static str,
+    #[case] report: &'static str,
+) {
+    let mut context = context.await;
+    let (principal, addr_id) = ("cyrus@example.com", "calendar");
+
+    let principal_store = context.principal_store;
+    principal_store
+        .insert_principal(
+            Principal {
+                id: principal.to_owned(),
+                displayname: None,
+                memberships: vec![],
+                password: None,
+                principal_type: PrincipalType::Individual,
+            },
+            false,
+        )
+        .await
+        .unwrap();
+    principal_store
+        .add_app_token(principal, "test".to_string(), "pass".to_string())
+        .await
+        .unwrap();
+    context.principal_store = principal_store;
+    let app = get_app(context.clone());
+
+    let url = format!("/caldav/principal/cyrus%40example.com/{addr_id}");
+
+    let request_template = || {
+        Request::builder()
+            .method("IMPORT")
+            .uri(&url)
+            .body(Body::from(ics))
+            .unwrap()
+    };
+    // Try with correct credentials
+    let mut request = request_template();
+    request
+        .headers_mut()
+        .typed_insert(Authorization::basic(principal, "pass"));
+    let response = app.clone().oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let mut request = Request::builder()
+        .method("REPORT")
+        .uri(&url)
+        .body(Body::from(report))
+        .unwrap();
+    request
+        .headers_mut()
+        .typed_insert(Authorization::basic(principal, "pass"));
+    let response = app.clone().oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::MULTI_STATUS);
+    let body = response.extract_string().await;
+    insta::assert_snapshot!(format!("{case}_report_body_email_principal"), body);
 }

--- a/tests/integration_tests/caldav/snapshots/run_integration_tests__integration_tests__caldav__calendar_report__0_report_body_email_principal.snap
+++ b/tests/integration_tests/caldav/snapshots/run_integration_tests__integration_tests__caldav__calendar_report__0_report_body_email_principal.snap
@@ -1,0 +1,53 @@
+---
+source: tests/integration_tests/caldav/calendar_report.rs
+assertion_line: 288
+expression: body
+---
+<?xml version="1.0" encoding="utf-8"?>
+<multistatus xmlns="DAV:" xmlns:CAL="urn:ietf:params:xml:ns:caldav" xmlns:CARD="urn:ietf:params:xml:ns:carddav" xmlns:CS="http://calendarserver.org/ns/" xmlns:PUSH="https://bitfire.at/webdav-push">
+    <response>
+        <href>/caldav/principal/cyrus%40example.com/calendar/abcd3.ics</href>
+        <propstat>
+            <prop>
+                <CAL:calendar-data>BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Example Corp.//CalDAV Client//EN
+BEGIN:VTIMEZONE
+LAST-MODIFIED:20040110T032845Z
+TZID:US/Eastern
+BEGIN:DAYLIGHT
+DTSTART:20000404T020000
+RRULE:FREQ=YEARLY;BYDAY=1SU;BYMONTH=4
+TZNAME:EDT
+TZOFFSETFROM:-0500
+TZOFFSETTO:-0400
+END:DAYLIGHT
+BEGIN:STANDARD
+DTSTART:20001026T020000
+RRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10
+TZNAME:EST
+TZOFFSETFROM:-0400
+TZOFFSETTO:-0500
+END:STANDARD
+END:VTIMEZONE
+BEGIN:VEVENT
+ATTENDEE;PARTSTAT=ACCEPTED;ROLE=CHAIR:mailto:cyrus@example.com
+ATTENDEE;PARTSTAT=NEEDS-ACTION:mailto:lisa@example.com
+DTSTAMP:20060206T001220Z
+DTSTART;TZID=US/Eastern:20060104T100000
+DURATION:PT1H
+LAST-MODIFIED:20060206T001330Z
+ORGANIZER:mailto:cyrus@example.com
+SEQUENCE:1
+STATUS:TENTATIVE
+SUMMARY:Event #3
+UID:abcd3
+X-ABC-GUID:E1CX5Dr-0007ym-Hz@example.com
+END:VEVENT
+END:VCALENDAR
+</CAL:calendar-data>
+            </prop>
+            <status>HTTP/1.1 200 OK</status>
+        </propstat>
+    </response>
+</multistatus>


### PR DESCRIPTION
Hi!

When setting rustical up with an OIDC provider, using the email-claim as the userid, I stumbled upon a problem where no events were returned from the "main" principal.

After investigating this a bit, I realized it stems from some URL-decoding getting out of sync (we decode the `href` property, but not the `path`) when trying to determine the filename, which means the calendar items aren't found.

This PR adds a test that exhibits this behaviour, and then does a simple (maybe to simple?) fix, by just changing the order of operations, and removing the path-prefix before URL-decoding.
