### PR TITLE
Introduce maintenance config for trashbin cleanup

### DIFF
--- a/.sqlx/query-0617307f008d45002076227d9db8300b4348b4c9987647234d4cdfa02c1c5ceb.json
+++ b/.sqlx/query-0617307f008d45002076227d9db8300b4348b4c9987647234d4cdfa02c1c5ceb.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "DELETE FROM calendarobjects WHERE deleted_at IS NOT NULL AND date(deleted_at) < date(?)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": []
+  },
+  "hash": "0617307f008d45002076227d9db8300b4348b4c9987647234d4cdfa02c1c5ceb"
+}

--- a/.sqlx/query-2a5706e39f56c770d0f64c09f52c032c88f4666230447e56cedece35b4c4e43a.json
+++ b/.sqlx/query-2a5706e39f56c770d0f64c09f52c032c88f4666230447e56cedece35b4c4e43a.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "DELETE FROM calendars WHERE deleted_at IS NOT NULL AND date(deleted_at) < date(?)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": []
+  },
+  "hash": "2a5706e39f56c770d0f64c09f52c032c88f4666230447e56cedece35b4c4e43a"
+}

--- a/.sqlx/query-2c8fa8077dbadf4a328b0eb4350091a14c2d30a3b467dc8079619afaf98c770a.json
+++ b/.sqlx/query-2c8fa8077dbadf4a328b0eb4350091a14c2d30a3b467dc8079619afaf98c770a.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "DELETE FROM birthday_calendars WHERE deleted_at IS NOT NULL AND date(deleted_at) < date(?)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": []
+  },
+  "hash": "2c8fa8077dbadf4a328b0eb4350091a14c2d30a3b467dc8079619afaf98c770a"
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3633,6 +3633,7 @@ dependencies = [
  "axum",
  "axum-extra",
  "caldata",
+ "chrono",
  "clap",
  "figment",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -172,6 +172,7 @@ sqlx.workspace = true
 async-trait.workspace = true
 uuid.workspace = true
 axum.workspace = true
+chrono.workspace = true
 
 opentelemetry = { version = "0.32", optional = true }
 opentelemetry-otlp = { version = "0.32", optional = true, features = [

--- a/crates/store/src/calendar_store.rs
+++ b/crates/store/src/calendar_store.rs
@@ -77,6 +77,8 @@ pub trait CalendarWriteStore: Send + Sync + 'static {
         use_trashbin: bool,
     ) -> Result<(), Error>;
     async fn restore_calendar(&self, principal: &str, name: &str) -> Result<(), Error>;
+    /// Removes all calendars marked for deletion before `until`
+    async fn delete_trashed_calendar_until(&self, limit: NaiveDate) -> Result<(), Error>;
     async fn import_calendar(
         &self,
         calendar: Calendar,
@@ -120,6 +122,8 @@ pub trait CalendarWriteStore: Send + Sync + 'static {
         cal_id: &str,
         object_id: &str,
     ) -> Result<(), Error>;
+    /// Removes all objects marked for deletion before `until`
+    async fn delete_trashed_objects_until(&self, limit: NaiveDate) -> Result<(), Error>;
 }
 
 pub trait CalendarStore: CalendarReadStore + CalendarWriteStore {}

--- a/crates/store/src/calendar_store.rs
+++ b/crates/store/src/calendar_store.rs
@@ -77,8 +77,8 @@ pub trait CalendarWriteStore: Send + Sync + 'static {
         use_trashbin: bool,
     ) -> Result<(), Error>;
     async fn restore_calendar(&self, principal: &str, name: &str) -> Result<(), Error>;
-    /// Removes all calendars marked for deletion before `until`
-    async fn delete_trashed_calendar_until(&self, limit: NaiveDate) -> Result<(), Error>;
+    /// Removes all calendars marked for deletion before specified date
+    async fn prune_deleted_calendars(&self, before: NaiveDate) -> Result<(), Error>;
     async fn import_calendar(
         &self,
         calendar: Calendar,
@@ -122,8 +122,8 @@ pub trait CalendarWriteStore: Send + Sync + 'static {
         cal_id: &str,
         object_id: &str,
     ) -> Result<(), Error>;
-    /// Removes all objects marked for deletion before `until`
-    async fn delete_trashed_objects_until(&self, limit: NaiveDate) -> Result<(), Error>;
+    /// Removes all objects marked for deletion before specified date
+    async fn prune_deleted_objects(&self, before: NaiveDate) -> Result<(), Error>;
 }
 
 pub trait CalendarStore: CalendarReadStore + CalendarWriteStore {}

--- a/crates/store/src/combined_calendar_store.rs
+++ b/crates/store/src/combined_calendar_store.rs
@@ -233,7 +233,7 @@ impl CalendarWriteStore for CombinedCalendarStore {
     ) -> Result<(), crate::Error> {
         self.default.delete_trashed_objects_until(limit).await?;
         for cal in self.stores.values() {
-            cal.delete_trashed_calendar_until(limit).await?;
+            cal.delete_trashed_objects_until(limit).await?;
         }
         Ok(())
     }

--- a/crates/store/src/combined_calendar_store.rs
+++ b/crates/store/src/combined_calendar_store.rs
@@ -170,6 +170,17 @@ impl CalendarWriteStore for CombinedCalendarStore {
             .await
     }
 
+    async fn delete_trashed_calendar_until(
+        &self,
+        limit: chrono::NaiveDate,
+    ) -> Result<(), crate::Error> {
+        self.default.delete_trashed_calendar_until(limit).await?;
+        for cal in self.stores.values() {
+            cal.delete_trashed_calendar_until(limit).await?;
+        }
+        Ok(())
+    }
+
     async fn import_calendar(
         &self,
         calendar: crate::Calendar,
@@ -214,5 +225,16 @@ impl CalendarWriteStore for CombinedCalendarStore {
         self.store_for_id(cal_id)
             .delete_object(principal, cal_id, object_id, use_trashbin)
             .await
+    }
+
+    async fn delete_trashed_objects_until(
+        &self,
+        limit: chrono::NaiveDate,
+    ) -> Result<(), crate::Error> {
+        self.default.delete_trashed_objects_until(limit).await?;
+        for cal in self.stores.values() {
+            cal.delete_trashed_calendar_until(limit).await?;
+        }
+        Ok(())
     }
 }

--- a/crates/store/src/combined_calendar_store.rs
+++ b/crates/store/src/combined_calendar_store.rs
@@ -170,13 +170,10 @@ impl CalendarWriteStore for CombinedCalendarStore {
             .await
     }
 
-    async fn delete_trashed_calendar_until(
-        &self,
-        limit: chrono::NaiveDate,
-    ) -> Result<(), crate::Error> {
-        self.default.delete_trashed_calendar_until(limit).await?;
+    async fn prune_deleted_calendars(&self, before: chrono::NaiveDate) -> Result<(), crate::Error> {
+        self.default.prune_deleted_calendars(before).await?;
         for cal in self.stores.values() {
-            cal.delete_trashed_calendar_until(limit).await?;
+            cal.prune_deleted_calendars(before).await?;
         }
         Ok(())
     }
@@ -227,13 +224,10 @@ impl CalendarWriteStore for CombinedCalendarStore {
             .await
     }
 
-    async fn delete_trashed_objects_until(
-        &self,
-        limit: chrono::NaiveDate,
-    ) -> Result<(), crate::Error> {
-        self.default.delete_trashed_objects_until(limit).await?;
+    async fn prune_deleted_objects(&self, before: chrono::NaiveDate) -> Result<(), crate::Error> {
+        self.default.prune_deleted_objects(before).await?;
         for cal in self.stores.values() {
-            cal.delete_trashed_objects_until(limit).await?;
+            cal.prune_deleted_objects(before).await?;
         }
         Ok(())
     }

--- a/crates/store_sqlite/src/addressbook_store/birthday_calendar.rs
+++ b/crates/store_sqlite/src/addressbook_store/birthday_calendar.rs
@@ -220,13 +220,13 @@ impl SqliteAddressbookStore {
         Ok(())
     }
 
-    async fn _delete_trashed_calendar_until<'e, E: Executor<'e, Database = Sqlite>>(
+    async fn _prune_deleted_calendars<'e, E: Executor<'e, Database = Sqlite>>(
         executor: E,
-        limit: chrono::NaiveDate,
+        before: chrono::NaiveDate,
     ) -> Result<u64, Error> {
         sqlx::query!(
             r"DELETE FROM birthday_calendars WHERE deleted_at IS NOT NULL AND date(deleted_at) < date(?)",
-            limit,
+            before,
         )
         .execute(executor)
         .await
@@ -435,8 +435,8 @@ impl CalendarWriteStore for SqliteAddressbookStore {
     }
 
     #[instrument(skip(self), fields(count = tracing::field::Empty))]
-    async fn delete_trashed_calendar_until(&self, limit: chrono::NaiveDate) -> Result<(), Error> {
-        let count = Self::_delete_trashed_calendar_until(&self.db, limit).await?;
+    async fn prune_deleted_calendars(&self, before: chrono::NaiveDate) -> Result<(), Error> {
+        let count = Self::_prune_deleted_calendars(&self.db, before).await?;
         tracing::Span::current().record("count", count);
         Ok(())
     }
@@ -484,7 +484,7 @@ impl CalendarWriteStore for SqliteAddressbookStore {
     }
 
     #[instrument]
-    async fn delete_trashed_objects_until(&self, _limit: chrono::NaiveDate) -> Result<(), Error> {
+    async fn prune_deleted_objects(&self, _before: chrono::NaiveDate) -> Result<(), Error> {
         Ok(())
     }
 }

--- a/crates/store_sqlite/src/addressbook_store/birthday_calendar.rs
+++ b/crates/store_sqlite/src/addressbook_store/birthday_calendar.rs
@@ -220,6 +220,21 @@ impl SqliteAddressbookStore {
         Ok(())
     }
 
+    async fn _delete_trashed_calendar_until<'e, E: Executor<'e, Database = Sqlite>>(
+        executor: E,
+        limit: chrono::NaiveDate,
+    ) -> Result<u64, Error> {
+        sqlx::query!(
+            r"DELETE FROM birthday_calendars WHERE deleted_at IS NOT NULL AND date(deleted_at) < date(?)",
+            limit,
+        )
+        .execute(executor)
+        .await
+        .map(|result| result.rows_affected())
+        .map_err(crate::Error::from)
+        .map_err(Into::into)
+    }
+
     #[instrument]
     async fn _update_birthday_calendar<'e, E: Executor<'e, Database = Sqlite>>(
         executor: E,
@@ -419,6 +434,13 @@ impl CalendarWriteStore for SqliteAddressbookStore {
         Self::_restore_birthday_calendar(&self.db, principal, id).await
     }
 
+    #[instrument(skip(self), fields(count = tracing::field::Empty))]
+    async fn delete_trashed_calendar_until(&self, limit: chrono::NaiveDate) -> Result<(), Error> {
+        let count = Self::_delete_trashed_calendar_until(&self.db, limit).await?;
+        tracing::Span::current().record("count", count);
+        Ok(())
+    }
+
     #[instrument]
     async fn import_calendar(
         &self,
@@ -459,5 +481,10 @@ impl CalendarWriteStore for SqliteAddressbookStore {
         _object_id: &str,
     ) -> Result<(), Error> {
         Err(Error::ReadOnly)
+    }
+
+    #[instrument]
+    async fn delete_trashed_objects_until(&self, _limit: chrono::NaiveDate) -> Result<(), Error> {
+        Ok(())
     }
 }

--- a/crates/store_sqlite/src/calendar_store.rs
+++ b/crates/store_sqlite/src/calendar_store.rs
@@ -478,13 +478,13 @@ impl SqliteCalendarStore {
         Ok(())
     }
 
-    async fn _delete_trashed_calendar_until<'e, E: Executor<'e, Database = Sqlite>>(
+    async fn _prune_deleted_calendars<'e, E: Executor<'e, Database = Sqlite>>(
         executor: E,
-        limit: chrono::NaiveDate,
+        before: chrono::NaiveDate,
     ) -> Result<u64, Error> {
         sqlx::query!(
             r"DELETE FROM calendars WHERE deleted_at IS NOT NULL AND date(deleted_at) < date(?)",
-            limit,
+            before,
         )
         .execute(executor)
         .await
@@ -745,13 +745,13 @@ impl SqliteCalendarStore {
         Ok((objects, deleted_objects, new_synctoken))
     }
 
-    async fn _delete_trashed_objects_until<'e, E: Executor<'e, Database = Sqlite>>(
+    async fn _prune_deleted_objects<'e, E: Executor<'e, Database = Sqlite>>(
         executor: E,
-        limit: chrono::NaiveDate,
+        before: chrono::NaiveDate,
     ) -> Result<u64, Error> {
         sqlx::query!(
             r"DELETE FROM calendarobjects WHERE deleted_at IS NOT NULL AND date(deleted_at) < date(?)",
-            limit,
+            before,
         )
         .execute(executor)
         .await
@@ -920,8 +920,8 @@ impl CalendarWriteStore for SqliteCalendarStore {
     }
 
     #[instrument(skip(self), fields(count = tracing::field::Empty))]
-    async fn delete_trashed_calendar_until(&self, limit: chrono::NaiveDate) -> Result<(), Error> {
-        let count = Self::_delete_trashed_calendar_until(&self.db, limit).await?;
+    async fn prune_deleted_calendars(&self, before: chrono::NaiveDate) -> Result<(), Error> {
+        let count = Self::_prune_deleted_calendars(&self.db, before).await?;
         tracing::Span::current().record("count", count);
         Ok(())
     }
@@ -1093,8 +1093,8 @@ impl CalendarWriteStore for SqliteCalendarStore {
     }
 
     #[instrument(skip(self), fields(count = tracing::field::Empty))]
-    async fn delete_trashed_objects_until(&self, until: chrono::NaiveDate) -> Result<(), Error> {
-        let count = Self::_delete_trashed_objects_until(&self.db, until).await?;
+    async fn prune_deleted_objects(&self, before: chrono::NaiveDate) -> Result<(), Error> {
+        let count = Self::_prune_deleted_objects(&self.db, before).await?;
         tracing::Span::current().record("count", count);
         Ok(())
     }

--- a/crates/store_sqlite/src/calendar_store.rs
+++ b/crates/store_sqlite/src/calendar_store.rs
@@ -478,6 +478,21 @@ impl SqliteCalendarStore {
         Ok(())
     }
 
+    async fn _delete_trashed_calendar_until<'e, E: Executor<'e, Database = Sqlite>>(
+        executor: E,
+        limit: chrono::NaiveDate,
+    ) -> Result<u64, Error> {
+        sqlx::query!(
+            r"DELETE FROM calendars WHERE deleted_at IS NOT NULL AND date(deleted_at) < date(?)",
+            limit,
+        )
+        .execute(executor)
+        .await
+        .map(|result| result.rows_affected())
+        .map_err(crate::Error::from)
+        .map_err(Into::into)
+    }
+
     async fn _list_objects<'e, E: Executor<'e, Database = Sqlite>>(
         executor: E,
         principal: &str,
@@ -729,6 +744,21 @@ impl SqliteCalendarStore {
 
         Ok((objects, deleted_objects, new_synctoken))
     }
+
+    async fn _delete_trashed_objects_until<'e, E: Executor<'e, Database = Sqlite>>(
+        executor: E,
+        limit: chrono::NaiveDate,
+    ) -> Result<u64, Error> {
+        sqlx::query!(
+            r"DELETE FROM calendarobjects WHERE deleted_at IS NOT NULL AND date(deleted_at) < date(?)",
+            limit,
+        )
+        .execute(executor)
+        .await
+        .map(|result| result.rows_affected())
+        .map_err(crate::Error::from)
+        .map_err(Into::into)
+    }
 }
 
 #[async_trait]
@@ -887,6 +917,13 @@ impl CalendarWriteStore for SqliteCalendarStore {
     #[instrument]
     async fn restore_calendar(&self, principal: &str, id: &str) -> Result<(), Error> {
         Self::_restore_calendar(&self.db, principal, id).await
+    }
+
+    #[instrument(skip(self), fields(count = tracing::field::Empty))]
+    async fn delete_trashed_calendar_until(&self, limit: chrono::NaiveDate) -> Result<(), Error> {
+        let count = Self::_delete_trashed_calendar_until(&self.db, limit).await?;
+        tracing::Span::current().record("count", count);
+        Ok(())
     }
 
     #[instrument]
@@ -1052,6 +1089,13 @@ impl CalendarWriteStore for SqliteCalendarStore {
             CollectionOperationInfo::Content { sync_token },
             self.get_calendar(principal, cal_id, true).await?.push_topic,
         );
+        Ok(())
+    }
+
+    #[instrument(skip(self), fields(count = tracing::field::Empty))]
+    async fn delete_trashed_objects_until(&self, until: chrono::NaiveDate) -> Result<(), Error> {
+        let count = Self::_delete_trashed_objects_until(&self.db, until).await?;
+        tracing::Span::current().record("count", count);
         Ok(())
     }
 }

--- a/crates/store_sqlite/src/tests/calendar_store.rs
+++ b/crates/store_sqlite/src/tests/calendar_store.rs
@@ -2,7 +2,24 @@
 mod tests {
     use crate::tests::{TestStoreContext, test_store_context};
     use rstest::rstest;
+    use rustical_ical::CalendarObject;
     use rustical_store::{Calendar, CalendarMetadata, CalendarReadStore, CalendarWriteStore};
+
+    const CALENDAR_OBJECT_ICS: &str = r#"
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//iCalendar Event//EN
+CALSCALE:GREGORIAN
+BEGIN:VEVENT
+UID:20260628T153000Z-123456@domain.com
+DTSTAMP:20260628T153000Z
+DTSTART:20260715T100000Z
+DTEND:20260715T110000Z
+SUMMARY:iCal Event
+DESCRIPTION:Basic calendar event.
+LOCATION:Meeting Room A
+END:VEVENT
+END:VCALENDAR"#;
 
     #[rstest]
     #[tokio::test]
@@ -51,6 +68,14 @@ mod tests {
             cal
         );
 
+        let object_id = "test-object";
+        let object =
+            CalendarObject::from_ics(CALENDAR_OBJECT_ICS.to_owned()).expect("to parse ics");
+
+        cal_store
+            .put_object(&cal.principal, &cal.id, object_id, object.clone(), false)
+            .await
+            .expect("to insert object");
         cal_store
             .delete_calendar("user", "cal", true)
             .await
@@ -60,6 +85,12 @@ mod tests {
             panic!()
         };
         assert!(err.is_not_found());
+
+        let fetched_object = cal_store
+            .get_object(&cal.principal, &cal.id, object_id, false)
+            .await
+            .expect("object remains");
+        assert_eq!(fetched_object.get_uid(), object.get_uid());
 
         cal_store.get_calendar("user", "cal", true).await.unwrap();
 
@@ -74,5 +105,13 @@ mod tests {
             panic!()
         };
         assert!(err.is_not_found());
+
+        match cal_store
+            .get_object(&cal.principal, &cal.id, object_id, false)
+            .await
+        {
+            Ok(_object) => panic!("Calendar deletion should cascade to relevant objects deletion"),
+            Err(error) => assert!(error.is_not_found()),
+        }
     }
 }

--- a/crates/store_sqlite/src/tests/calendar_store.rs
+++ b/crates/store_sqlite/src/tests/calendar_store.rs
@@ -114,4 +114,88 @@ END:VCALENDAR"#;
             Err(error) => assert!(error.is_not_found()),
         }
     }
+
+    #[rstest]
+    #[tokio::test]
+    async fn should_deleted_trashed_calendar_andobjects_by_date_limit(
+        #[future]
+        #[from(test_store_context)]
+        context: TestStoreContext,
+    ) {
+        let TestStoreContext { cal_store, .. } = context.await;
+
+        let cal_store = cal_store;
+
+        let cal = Calendar {
+            principal: "user".to_string(),
+            timezone_id: None,
+            deleted_at: None,
+            meta: CalendarMetadata::default(),
+            id: "trashed-cal".to_string(),
+            synctoken: 0,
+            subscription_url: None,
+            push_topic: "trashed".to_string(),
+            components: vec![],
+        };
+
+        cal_store.insert_calendar(cal.clone()).await.unwrap();
+
+        let object_id = "test-trash-object";
+        let object =
+            CalendarObject::from_ics(CALENDAR_OBJECT_ICS.to_owned()).expect("to parse ics");
+
+        cal_store
+            .put_object(&cal.principal, &cal.id, object_id, object.clone(), false)
+            .await
+            .expect("to insert object");
+
+        let now = chrono::Utc::now().date_naive();
+        //Delete object and calendar
+        cal_store
+            .delete_object(&cal.principal, &cal.id, object_id, true)
+            .await
+            .expect("to delete");
+        cal_store
+            .delete_calendar(&cal.principal, &cal.id, true)
+            .await
+            .unwrap();
+
+        //Verify we delete only BEFORE timestamp
+        cal_store
+            .delete_trashed_objects_until(now)
+            .await
+            .expect("success");
+        cal_store
+            .get_object(&cal.principal, &cal.id, object_id, true)
+            .await
+            .expect("Nothing deleted yet");
+        cal_store
+            .delete_trashed_calendar_until(now)
+            .await
+            .expect("success");
+        cal_store
+            .get_calendar(&cal.principal, &cal.id, true)
+            .await
+            .expect("Nothing deleted yet");
+
+        //delete everything that was marked for deletion before tomorrow
+        cal_store
+            .delete_trashed_objects_until(now + chrono::Duration::days(1))
+            .await
+            .expect("success");
+        let error = cal_store
+            .get_object(&cal.principal, &cal.id, object_id, true)
+            .await
+            .expect_err("object should be deleted");
+        assert!(error.is_not_found());
+        cal_store
+            .delete_trashed_calendar_until(now + chrono::Duration::days(1))
+            .await
+            .expect("success");
+        let error = cal_store
+            .get_calendar(&cal.principal, &cal.id, true)
+            .await
+            .expect_err("calendar should be deleted");
+        assert!(error.is_not_found());
+    }
 }

--- a/crates/store_sqlite/src/tests/calendar_store.rs
+++ b/crates/store_sqlite/src/tests/calendar_store.rs
@@ -161,16 +161,13 @@ END:VCALENDAR"#;
             .unwrap();
 
         //Verify we delete only BEFORE timestamp
-        cal_store
-            .delete_trashed_objects_until(now)
-            .await
-            .expect("success");
+        cal_store.prune_deleted_objects(now).await.expect("success");
         cal_store
             .get_object(&cal.principal, &cal.id, object_id, true)
             .await
             .expect("Nothing deleted yet");
         cal_store
-            .delete_trashed_calendar_until(now)
+            .prune_deleted_calendars(now)
             .await
             .expect("success");
         cal_store
@@ -180,7 +177,7 @@ END:VCALENDAR"#;
 
         //delete everything that was marked for deletion before tomorrow
         cal_store
-            .delete_trashed_objects_until(now + chrono::Duration::days(1))
+            .prune_deleted_objects(now + chrono::Duration::days(1))
             .await
             .expect("success");
         let error = cal_store
@@ -189,7 +186,7 @@ END:VCALENDAR"#;
             .expect_err("object should be deleted");
         assert!(error.is_not_found());
         cal_store
-            .delete_trashed_calendar_until(now + chrono::Duration::days(1))
+            .prune_deleted_calendars(now + chrono::Duration::days(1))
             .await
             .expect("success");
         let error = cal_store

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,6 +1,6 @@
 use crate::config::{
     Config, DataStoreConfig, DavPushConfig, HttpConfig, NextcloudLoginConfig,
-    SqliteDataStoreConfig, TracingConfig,
+    SqliteDataStoreConfig, TracingConfig, MaintenanceConfig
 };
 use clap::Parser;
 use rustical_caldav::CalDavConfig;
@@ -34,6 +34,7 @@ pub fn cmd_gen_config(_args: GenConfigArgs) -> anyhow::Result<()> {
         oidc: None,
         dav_push: DavPushConfig::default(),
         nextcloud_login: NextcloudLoginConfig::default(),
+        maintenance: MaintenanceConfig::default(),
     };
     let generated_config = toml::to_string(&config)?;
     println!("{generated_config}");

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,6 +1,6 @@
 use crate::config::{
-    Config, DataStoreConfig, DavPushConfig, HttpConfig, NextcloudLoginConfig,
-    SqliteDataStoreConfig, TracingConfig, MaintenanceConfig
+    Config, DataStoreConfig, DavPushConfig, HttpConfig, MaintenanceConfig, NextcloudLoginConfig,
+    SqliteDataStoreConfig, TracingConfig,
 };
 use clap::Parser;
 use rustical_caldav::CalDavConfig;

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,5 @@
 use std::{path::PathBuf, str::FromStr};
+use core::num::NonZeroU32;
 
 use anyhow::anyhow;
 use reqwest::Url;
@@ -239,6 +240,36 @@ impl Default for NextcloudLoginConfig {
     }
 }
 
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+#[serde(deny_unknown_fields, default)]
+pub struct MaintenanceCalendarTrashbinConfig {
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deleted_calendar_lifetime: Option<NonZeroU32>,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deleted_object_lifetime: Option<NonZeroU32>,
+}
+
+impl MaintenanceCalendarTrashbinConfig {
+    #[inline]
+    pub fn is_cleanup_required(&self) -> bool {
+        self.deleted_calendar_lifetime.is_some() || self.deleted_object_lifetime.is_some()
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+#[serde(deny_unknown_fields, default)]
+pub struct MaintenanceTrashbinConfig {
+    pub calendar: MaintenanceCalendarTrashbinConfig
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+#[serde(deny_unknown_fields, default)]
+pub struct MaintenanceConfig {
+    pub trashbin: MaintenanceTrashbinConfig,
+}
+
 #[derive(Deserialize, Serialize, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct Config {
@@ -257,4 +288,6 @@ pub struct Config {
     pub nextcloud_login: NextcloudLoginConfig,
     #[serde(default)]
     pub caldav: CalDavConfig,
+    #[serde(default)]
+    pub maintenance: MaintenanceConfig,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,5 @@
-use std::{path::PathBuf, str::FromStr};
 use core::num::NonZeroU32;
+use std::{path::PathBuf, str::FromStr};
 
 use anyhow::anyhow;
 use reqwest::Url;
@@ -252,8 +252,9 @@ pub struct MaintenanceCalendarTrashbinConfig {
 }
 
 impl MaintenanceCalendarTrashbinConfig {
+    #[must_use]
     #[inline]
-    pub fn is_cleanup_required(&self) -> bool {
+    pub const fn is_cleanup_required(&self) -> bool {
         self.deleted_calendar_lifetime.is_some() || self.deleted_object_lifetime.is_some()
     }
 }
@@ -261,7 +262,7 @@ impl MaintenanceCalendarTrashbinConfig {
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 #[serde(deny_unknown_fields, default)]
 pub struct MaintenanceTrashbinConfig {
-    pub calendar: MaintenanceCalendarTrashbinConfig
+    pub calendar: MaintenanceCalendarTrashbinConfig,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -242,33 +242,10 @@ impl Default for NextcloudLoginConfig {
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 #[serde(deny_unknown_fields, default)]
-pub struct MaintenanceCalendarTrashbinConfig {
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub deleted_calendar_lifetime: Option<NonZeroU32>,
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub deleted_object_lifetime: Option<NonZeroU32>,
-}
-
-impl MaintenanceCalendarTrashbinConfig {
-    #[must_use]
-    #[inline]
-    pub const fn is_cleanup_required(&self) -> bool {
-        self.deleted_calendar_lifetime.is_some() || self.deleted_object_lifetime.is_some()
-    }
-}
-
-#[derive(Debug, Clone, Deserialize, Serialize, Default)]
-#[serde(deny_unknown_fields, default)]
-pub struct MaintenanceTrashbinConfig {
-    pub calendar: MaintenanceCalendarTrashbinConfig,
-}
-
-#[derive(Debug, Clone, Deserialize, Serialize, Default)]
-#[serde(deny_unknown_fields, default)]
 pub struct MaintenanceConfig {
-    pub trashbin: MaintenanceTrashbinConfig,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trash_retention_days: Option<NonZeroU32>,
 }
 
 #[derive(Deserialize, Serialize, Clone)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ use tracing::{info, warn};
 
 pub mod app;
 mod commands;
+mod tasks;
 pub use commands::*;
 pub mod config;
 mod setup_tracing;
@@ -151,6 +152,13 @@ pub async fn cmd_default(
     );
 
     let mut provided_listeners = ProvidedListeners::from_env()?;
+    if config.maintenance.trashbin.calendar.is_cleanup_required() {
+        tokio::spawn(tasks::cleanup_trashed_calendar_entities(
+            cal_store.clone(),
+            config.maintenance.trashbin.calendar,
+            shutdown_signal(),
+        ));
+    }
 
     let bind_config = config.http.bind_config()?;
     let serve_task = match bind_config {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,10 +152,10 @@ pub async fn cmd_default(
     );
 
     let mut provided_listeners = ProvidedListeners::from_env()?;
-    if config.maintenance.trashbin.calendar.is_cleanup_required() {
+    if let Some(trash_retention_days) = config.maintenance.trash_retention_days {
         tokio::spawn(tasks::cleanup_trashed_calendar_entities(
             cal_store.clone(),
-            config.maintenance.trashbin.calendar,
+            trash_retention_days,
             shutdown_signal(),
         ));
     }

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -2,6 +2,7 @@ use core::future::Future;
 use core::num::NonZeroU32;
 use std::sync::Arc;
 
+use chrono::NaiveDate;
 use rustical_store::CalendarStore;
 
 pub async fn cleanup_trashed_calendar_entities(
@@ -15,17 +16,9 @@ pub async fn cleanup_trashed_calendar_entities(
         trash_retention_days: NonZeroU32,
     ) {
         //Default sub operation can panic so avoid it
-        let before =
-            match time.checked_sub_days(chrono::Days::new(trash_retention_days.get().into())) {
-                Some(before) => before,
-                None => {
-                    const UTC: chrono::NaiveDate = match chrono::NaiveDate::from_epoch_days(0) {
-                        Some(utc) => utc,
-                        None => unreachable!(),
-                    };
-                    UTC
-                }
-            };
+        let before = time
+            .checked_sub_days(chrono::Days::new(trash_retention_days.get().into()))
+            .unwrap_or(NaiveDate::MIN);
 
         if let Err(error) = cal_store.prune_deleted_calendars(before).await {
             tracing::error!(

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -66,3 +66,72 @@ pub async fn cleanup_trashed_calendar_entities(
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use core::future;
+    use core::num::NonZeroU32;
+    use std::sync::Arc;
+
+    use super::cleanup_trashed_calendar_entities;
+    use rustical_store::auth::AuthenticationProvider;
+    use rustical_store::{CalendarReadStore, CalendarWriteStore};
+    use rustical_store_sqlite::calendar_store::SqliteCalendarStore;
+    use rustical_store_sqlite::create_db_pool;
+    use rustical_store_sqlite::principal_store::SqlitePrincipalStore;
+
+    const CONFIG_RETENTION_DAYS: NonZeroU32 = match NonZeroU32::new(1) {
+        Some(result) => result,
+        None => unreachable!(),
+    };
+
+    #[tokio::test]
+    async fn should_shutdown_cleanup_task_on_demand() {
+        let db = create_db_pool("sqlite://:memory:", true)
+            .await
+            .expect("to create db");
+        let (send, _recv) = tokio::sync::mpsc::channel(1000);
+        let cal_store = Arc::new(SqliteCalendarStore::new(db.clone(), send, true));
+        let principal_store = SqlitePrincipalStore::new(db);
+        let principal = rustical_store::auth::Principal {
+            id: "user".to_owned(),
+            displayname: None,
+            password: None,
+            principal_type: rustical_store::auth::PrincipalType::Individual,
+            memberships: Vec::new(),
+        };
+        principal_store
+            .insert_principal(principal, false)
+            .await
+            .expect("to insert principal");
+
+        let calendar = rustical_store::Calendar {
+            meta: Default::default(),
+            principal: "user".to_owned(),
+            id: "id".to_owned(),
+            ..Default::default()
+        };
+        cal_store
+            .insert_calendar(calendar)
+            .await
+            .expect("insert calendar");
+        cal_store
+            .delete_calendar("user", "id", true)
+            .await
+            .expect("delete into trashbin");
+
+        //should exit task as soon as it enters loop
+        cleanup_trashed_calendar_entities(
+            cal_store.clone(),
+            CONFIG_RETENTION_DAYS,
+            future::ready(()),
+        )
+        .await;
+
+        let result = cal_store
+            .get_calendar("user", "id", true)
+            .await
+            .expect("should not be deleted on the same day creation");
+        assert_eq!(result.id, "id");
+    }
+}

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -1,0 +1,57 @@
+use core::future::Future;
+use std::sync::Arc;
+
+use crate::config::MaintenanceCalendarTrashbinConfig;
+use rustical_store::CalendarStore;
+
+pub async fn cleanup_trashed_calendar_entities(
+    cal_store: Arc<dyn CalendarStore>,
+    config: MaintenanceCalendarTrashbinConfig,
+    shutdown_signal: impl Future + Send + 'static,
+) {
+    async fn delete_trashed_calendar_entities(
+        time: chrono::NaiveDate,
+        cal_store: &dyn CalendarStore,
+        config: &MaintenanceCalendarTrashbinConfig,
+    ) {
+        if let Some(calendar_days_life) = config.deleted_calendar_lifetime {
+            let limit = time - chrono::Duration::days(calendar_days_life.get().into());
+            if let Err(error) = cal_store.delete_trashed_calendar_until(limit).await {
+                tracing::error!(
+                    ?error,
+                    "Maintenance cleanup of calendar trashbin failed: {}",
+                    error
+                );
+            }
+        }
+
+        if let Some(object_days_life) = config.deleted_object_lifetime {
+            let limit = time - chrono::Duration::days(object_days_life.get().into());
+            if let Err(error) = cal_store.delete_trashed_objects_until(limit).await {
+                tracing::error!(
+                    ?error,
+                    "Maintenance cleanup of object trashbin failed: {}",
+                    error
+                );
+            }
+        }
+    }
+
+    //Perform initial cleanup in case user doesn't let server to run for more than 24 hours
+    delete_trashed_calendar_entities(chrono::Utc::now().naive_utc().date(), &*cal_store, &config)
+        .await;
+
+    let mut shutdown_signal = core::pin::pin!(shutdown_signal);
+    //Deletion are unlikely to be frequent so that check it daily
+    let mut interval = tokio::time::interval(tokio::time::Duration::from_hours(24));
+    loop {
+        tokio::select! {
+            _ = interval.tick() => {
+                delete_trashed_calendar_entities(chrono::Utc::now().naive_utc().date(), &*cal_store, &config).await;
+            }
+            _ = &mut shutdown_signal => {
+                break;
+            }
+        }
+    }
+}

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -1,53 +1,52 @@
 use core::future::Future;
+use core::num::NonZeroU32;
 use std::sync::Arc;
 
-use crate::config::MaintenanceCalendarTrashbinConfig;
 use rustical_store::CalendarStore;
 
 pub async fn cleanup_trashed_calendar_entities(
     cal_store: Arc<dyn CalendarStore>,
-    config: MaintenanceCalendarTrashbinConfig,
+    trash_retention_days: NonZeroU32,
     shutdown_signal: impl Future + Send + 'static,
 ) {
     async fn delete_trashed_calendar_entities(
         time: chrono::NaiveDate,
         cal_store: &dyn CalendarStore,
-        config: &MaintenanceCalendarTrashbinConfig,
+        trash_retention_days: NonZeroU32,
     ) {
-        if let Some(calendar_days_life) = config.deleted_calendar_lifetime {
-            let limit = time - chrono::Duration::days(calendar_days_life.get().into());
-            if let Err(error) = cal_store.delete_trashed_calendar_until(limit).await {
-                tracing::error!(
-                    ?error,
-                    "Maintenance cleanup of calendar trashbin failed: {}",
-                    error
-                );
-            }
+        let before = time - chrono::Duration::days(trash_retention_days.get().into());
+        if let Err(error) = cal_store.prune_deleted_calendars(before).await {
+            tracing::error!(
+                ?error,
+                "Maintenance cleanup of calendar trashbin failed: {}",
+                error
+            );
         }
 
-        if let Some(object_days_life) = config.deleted_object_lifetime {
-            let limit = time - chrono::Duration::days(object_days_life.get().into());
-            if let Err(error) = cal_store.delete_trashed_objects_until(limit).await {
-                tracing::error!(
-                    ?error,
-                    "Maintenance cleanup of object trashbin failed: {}",
-                    error
-                );
-            }
+        if let Err(error) = cal_store.prune_deleted_objects(before).await {
+            tracing::error!(
+                ?error,
+                "Maintenance cleanup of object trashbin failed: {}",
+                error
+            );
         }
     }
 
-    //Perform initial cleanup in case user doesn't let server to run for more than 24 hours
-    delete_trashed_calendar_entities(chrono::Utc::now().naive_utc().date(), &*cal_store, &config)
-        .await;
+    // Perform initial cleanup in case user doesn't let server run for more than 24 hours
+    delete_trashed_calendar_entities(
+        chrono::Utc::now().naive_utc().date(),
+        &*cal_store,
+        trash_retention_days,
+    )
+    .await;
 
     let mut shutdown_signal = core::pin::pin!(shutdown_signal);
-    //Deletion are unlikely to be frequent so that check it daily
+    // Deletion is unlikely to be frequent hence daily
     let mut interval = tokio::time::interval(tokio::time::Duration::from_hours(24));
     loop {
         tokio::select! {
             _ = interval.tick() => {
-                delete_trashed_calendar_entities(chrono::Utc::now().naive_utc().date(), &*cal_store, &config).await;
+                delete_trashed_calendar_entities(chrono::Utc::now().naive_utc().date(), &*cal_store, trash_retention_days).await;
             }
             _ = &mut shutdown_signal => {
                 break;

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -14,7 +14,19 @@ pub async fn cleanup_trashed_calendar_entities(
         cal_store: &dyn CalendarStore,
         trash_retention_days: NonZeroU32,
     ) {
-        let before = time - chrono::Duration::days(trash_retention_days.get().into());
+        //Default sub operation can panic so avoid it
+        let before =
+            match time.checked_sub_days(chrono::Days::new(trash_retention_days.get().into())) {
+                Some(before) => before,
+                None => {
+                    const UTC: chrono::NaiveDate = match chrono::NaiveDate::from_epoch_days(0) {
+                        Some(utc) => utc,
+                        None => unreachable!(),
+                    };
+                    UTC
+                }
+            };
+
         if let Err(error) = cal_store.prune_deleted_calendars(before).await {
             tracing::error!(
                 ?error,

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -66,6 +66,7 @@ pub fn rustical_process(
                     dav_push: Default::default(),
                     nextcloud_login: Default::default(),
                     caldav: Default::default(),
+                    maintenance: Default::default(),
                 },
                 Some(cloned_start_notify),
                 false,

--- a/tests/http_integration.rs
+++ b/tests/http_integration.rs
@@ -96,6 +96,7 @@ async fn test_initial_setup() {
                 dav_push: Default::default(),
                 nextcloud_login: Default::default(),
                 caldav: Default::default(),
+                maintenance: Default::default(),
             },
         )
         .await
@@ -125,6 +126,7 @@ async fn test_initial_setup() {
                 dav_push: Default::default(),
                 nextcloud_login: Default::default(),
                 caldav: Default::default(),
+                maintenance: Default::default(),
             },
         )
         .await
@@ -231,6 +233,7 @@ async fn test_principal_impersonation() {
             dav_push: Default::default(),
             nextcloud_login: Default::default(),
             caldav: Default::default(),
+            maintenance: Default::default(),
         };
 
         // Create principal


### PR DESCRIPTION
Fixes #228

This PR introduces two new interfaces to write store:
- `prune_deleted_calendars` - Delete all calendars before specified date
- `prune_deleted_objects` - Delete all calender's objects before specified date

To enable this user will need to specify explicit limits in new `maintenance` section of config:
- `maintenance.trash_retention_days` - Number of days that _all_ entities should remain in trashbin (i.e. marked for deletion) before being cleaned up

A task will be spawned on tokio runtime to maintain trashbin by daily cleaning up using above mentioned configuration (in addition to doing it every time on startup)

This should facilitate basic need to cleanup trashbin so as long as user sets up configuration.
I kept current behaviour as default (i.e. no daily cleanup at all), but I believe it might be wise to have some limit on by default at least in new major version