### PR TITLE
feat: support Docker secrets via _FILE env var suffix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1366,6 +1366,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "figment_file_env_provider"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5697e4c3f577031bec1c4b8faacf86d056d80251a85546cefed29f053e67c129"
+dependencies = [
+ "figment",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3636,6 +3645,7 @@ dependencies = [
  "chrono",
  "clap",
  "figment",
+ "figment_file_env_provider",
  "futures-util",
  "headers",
  "http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,6 +189,7 @@ tracing-subscriber = { version = "0.3", features = [
   "registry",
 ] }
 figment = { version = "0.10", features = ["env", "toml"] }
+figment_file_env_provider = "0.2"
 tower-sessions.workspace = true
 rpassword.workspace = true
 tower.workspace = true

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ use anyhow::Result;
 use clap::Parser;
 use figment::Figment;
 use figment::providers::{Env, Format, Toml};
+use figment_file_env_provider::FileEnv;
 use rustical::config::Config;
 use rustical::{Args, Command};
 use rustical::{cmd_default, cmd_gen_config, cmd_health, cmd_principals};
@@ -15,7 +16,7 @@ async fn main() -> Result<()> {
     let parse_config = || {
         Figment::new()
             .merge(Toml::file(&args.config_file))
-            .merge(Env::prefixed("RUSTICAL_").split("__"))
+            .merge(FileEnv::from_env(Env::prefixed("RUSTICAL_").split("__")))
             .extract()
             // Clippy appeasement clippy::result_large_err
             .map_err(anyhow::Error::from)


### PR DESCRIPTION
## Summary

- Adds [`figment_file_env_provider`](https://github.com/nitnelave/figment_file_env_provider) as a dependency (authored by the LLDAP maintainer for exactly this use case)
- Wraps the existing `Env::prefixed("RUSTICAL_")` provider with `FileEnv::from_env(...)` — a one-line change in `main.rs`
- Any `RUSTICAL_*` environment variable can now be loaded from a file by appending `_FILE` to the variable name

## Usage

```yaml
# compose.yml
secrets:
  - oidc_client_secret

services:
  rustical:
    secrets:
      - oidc_client_secret
    environment:
      RUSTICAL_OIDC__CLIENT_SECRET_FILE: /run/secrets/oidc_client_secret
```

If both `RUSTICAL_OIDC__CLIENT_SECRET` and `RUSTICAL_OIDC__CLIENT_SECRET_FILE` are set, the plain env var takes precedence. If a `_FILE` path is set but the file cannot be read, startup fails with a clear error.

## Test plan

- [ ] Existing env var config continues to work unchanged
- [ ] Setting `RUSTICAL_OIDC__CLIENT_SECRET_FILE` to a valid file path loads the secret correctly
- [ ] Setting `_FILE` to a nonexistent path produces a descriptive error on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)