### PR TITLE
frontend: make DOCTYPE and UTF-8 lowercase to get better compression

### DIFF
--- a/crates/frontend/public/templates/layouts/default.html
+++ b/crates/frontend/public/templates/layouts/default.html
@@ -1,8 +1,8 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
 
 <head>
-  <meta charset="UTF-8">
+  <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="color-scheme" content="light dark">
   <title>{% block title %}RustiCal{% endblock %}</title>

--- a/crates/frontend/src/lib.rs
+++ b/crates/frontend/src/lib.rs
@@ -149,7 +149,7 @@ async fn unauthorized_handler(mut request: Request, next: Next) -> Response {
         hdrs.typed_insert(ContentType::html());
         return resp
             .body(Body::new(format!(
-                r#"<!Doctype html>
+                r#"<!doctype html>
 <html>
     <head>
         <meta http-equiv="refresh" content="1; url={login_url}" />


### PR DESCRIPTION
Better compression.
- [endtimes.dev : why-lowercase-letters-save-data](https://endtimes.dev/why-lowercase-letters-save-data/)
- [MDN Glossary : Doctype](https://developer.mozilla.org/en-US/docs/Glossary/Doctype)
