### PR TITLE
Add timeout to WebDAV-Push notifier HTTP client

### DIFF
--- a/crates/dav_push/src/lib.rs
+++ b/crates/dav_push/src/lib.rs
@@ -184,6 +184,8 @@ async fn send_payload(payload: &str, subsciption: &Subscription) -> Result<(), N
         .map_err(|_| NotifierError::InvalidKeyEncoding)?;
 
     let client = reqwest::ClientBuilder::new()
+        .timeout(Duration::from_secs(30))
+        .connect_timeout(Duration::from_secs(10))
         .build()
         .map_err(NotifierError::from)?;
 


### PR DESCRIPTION
The push notifier builds its reqwest client with no timeout, so client.execute on a subscription's push_resource can hang forever. That URL comes straight from whatever a client put in the push-register body, and send_message walks the subscriptions one at a time awaiting each send. So a single push endpoint that accepts the connection but never responds stalls the whole notifier task and nobody gets notifications until the process restarts. I added a request timeout and a connect timeout to the client so a dead or slow endpoint just fails that one send and the loop keeps going. Mirrors the caution already in the OIDC client.