### PR TITLE
Add option to stop advertising vCard 4.0

### DIFF
--- a/crates/carddav/src/addressbook/methods/get.rs
+++ b/crates/carddav/src/addressbook/methods/get.rs
@@ -15,13 +15,13 @@ use rustical_store::auth::Principal;
 use std::str::FromStr;
 use tracing::instrument;
 
-#[instrument(skip(addr_store, dav_push_store))]
+#[instrument(skip(addr_store, dav_push_store, config))]
 pub async fn route_get<AS: AddressbookStore, DP: DavPushStore>(
     Path((principal, addressbook_id)): Path<(String, String)>,
     State(AddressbookResourceService {
         addr_store,
         dav_push_store,
-        ..
+        config,
     }): State<AddressbookResourceService<AS, DP>>,
     user: Principal,
     method: Method,
@@ -37,6 +37,7 @@ pub async fn route_get<AS: AddressbookStore, DP: DavPushStore>(
     let addressbook_resource = AddressbookResource {
         addressbook: addressbook.clone(),
         vapid_pubkey,
+        advertise_vcard4: config.advertise_vcard4,
     };
     if !addressbook_resource
         .get_user_privileges(&user)?

--- a/crates/carddav/src/addressbook/methods/post.rs
+++ b/crates/carddav/src/addressbook/methods/post.rs
@@ -36,6 +36,7 @@ pub async fn route_post<AS: AddressbookStore, DP: DavPushStore>(
     let addressbook_resource = AddressbookResource {
         addressbook,
         vapid_pubkey,
+        advertise_vcard4: resource_service.config.advertise_vcard4,
     };
     if !addressbook_resource
         .get_user_privileges(&user)?

--- a/crates/carddav/src/addressbook/prop.rs
+++ b/crates/carddav/src/addressbook/prop.rs
@@ -46,20 +46,35 @@ pub struct SupportedAddressData {
     address_data_type: &'static [AddressDataType],
 }
 
+const ADDRESS_DATA_VCARD3: AddressDataType = AddressDataType {
+    content_type: "text/vcard",
+    version: "3.0",
+};
+const ADDRESS_DATA_VCARD4: AddressDataType = AddressDataType {
+    content_type: "text/vcard",
+    version: "4.0",
+};
+
+const SUPPORTED_ADDRESS_DATA_3: &[AddressDataType] = &[ADDRESS_DATA_VCARD3];
+const SUPPORTED_ADDRESS_DATA_3_AND_4: &[AddressDataType] =
+    &[ADDRESS_DATA_VCARD3, ADDRESS_DATA_VCARD4];
+
+impl SupportedAddressData {
+    #[must_use]
+    pub const fn new(advertise_vcard4: bool) -> Self {
+        Self {
+            address_data_type: if advertise_vcard4 {
+                SUPPORTED_ADDRESS_DATA_3_AND_4
+            } else {
+                SUPPORTED_ADDRESS_DATA_3
+            },
+        }
+    }
+}
+
 impl Default for SupportedAddressData {
     fn default() -> Self {
-        Self {
-            address_data_type: &[
-                AddressDataType {
-                    content_type: "text/vcard",
-                    version: "3.0",
-                },
-                AddressDataType {
-                    content_type: "text/vcard",
-                    version: "4.0",
-                },
-            ],
-        }
+        Self::new(true)
     }
 }
 

--- a/crates/carddav/src/addressbook/resource.rs
+++ b/crates/carddav/src/addressbook/resource.rs
@@ -19,6 +19,7 @@ use std::borrow::Cow;
 pub struct AddressbookResource {
     pub(crate) addressbook: Addressbook,
     pub(crate) vapid_pubkey: VapidPublicKeyB64,
+    pub(crate) advertise_vcard4: bool,
 }
 
 impl ResourceName for AddressbookResource {
@@ -80,7 +81,9 @@ impl Resource for AddressbookResource {
                         )
                     }
                     AddressbookPropName::SupportedAddressData => {
-                        AddressbookProp::SupportedAddressData(SupportedAddressData::default())
+                        AddressbookProp::SupportedAddressData(SupportedAddressData::new(
+                            self.advertise_vcard4,
+                        ))
                     }
                 })
             }

--- a/crates/carddav/src/addressbook/service.rs
+++ b/crates/carddav/src/addressbook/service.rs
@@ -6,7 +6,7 @@ use crate::addressbook::methods::get::route_get;
 use crate::addressbook::methods::import::route_import;
 use crate::addressbook::methods::post::route_post;
 use crate::addressbook::resource::AddressbookResource;
-use crate::{CardDavPrincipalUri, Error};
+use crate::{CardDavConfig, CardDavPrincipalUri, Error};
 use async_trait::async_trait;
 use axum::Router;
 use axum::extract::Request;
@@ -24,13 +24,19 @@ use tower::Service;
 pub struct AddressbookResourceService<AS: AddressbookStore, DP: DavPushStore> {
     pub(crate) addr_store: Arc<AS>,
     pub(crate) dav_push_store: Arc<DP>,
+    pub(crate) config: Arc<CardDavConfig>,
 }
 
 impl<A: AddressbookStore, DP: DavPushStore> AddressbookResourceService<A, DP> {
-    pub const fn new(addr_store: Arc<A>, dav_push_store: Arc<DP>) -> Self {
+    pub const fn new(
+        addr_store: Arc<A>,
+        dav_push_store: Arc<DP>,
+        config: Arc<CardDavConfig>,
+    ) -> Self {
         Self {
             addr_store,
             dav_push_store,
+            config,
         }
     }
 }
@@ -40,6 +46,7 @@ impl<A: AddressbookStore, DP: DavPushStore> Clone for AddressbookResourceService
         Self {
             addr_store: self.addr_store.clone(),
             dav_push_store: self.dav_push_store.clone(),
+            config: self.config.clone(),
         }
     }
 }
@@ -71,6 +78,7 @@ impl<AS: AddressbookStore, DP: DavPushStore> ResourceService
         Ok(AddressbookResource {
             addressbook,
             vapid_pubkey,
+            advertise_vcard4: self.config.advertise_vcard4,
         })
     }
 

--- a/crates/carddav/src/addressbook/tests.rs
+++ b/crates/carddav/src/addressbook/tests.rs
@@ -39,6 +39,7 @@ fn test_propfind() {
     let resource = AddressbookResource {
         addressbook: addressbook.clone(),
         vapid_pubkey,
+        advertise_vcard4: true,
     };
     let response = resource
         .propfind(
@@ -55,4 +56,67 @@ fn test_propfind() {
 
     insta::assert_debug_snapshot!(response);
     insta::assert_snapshot!(response.serialize_to_string().unwrap());
+}
+
+#[rstest::rstest]
+#[case(true, true)]
+#[case(false, false)]
+fn test_supported_address_data_advertise_vcard4(
+    #[case] advertise_vcard4: bool,
+    #[case] expect_vcard4: bool,
+) {
+    let propfind = AddressbookResource::parse_propfind(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+        <propfind xmlns="DAV:" xmlns:C="urn:ietf:params:xml:ns:carddav">
+            <prop><C:supported-address-data/></prop>
+        </propfind>"#,
+    )
+    .unwrap();
+
+    let principal = Principal {
+        id: "user".to_string(),
+        displayname: None,
+        principal_type: rustical_store::auth::PrincipalType::Individual,
+        password: None,
+        memberships: vec![],
+    };
+    let addressbook = Addressbook {
+        id: "yeet".to_string(),
+        principal: "user".to_string(),
+        displayname: None,
+        description: None,
+        deleted_at: None,
+        synctoken: 0,
+        push_topic: "asdasd".to_string(),
+    };
+    let resource = AddressbookResource {
+        addressbook: addressbook.clone(),
+        vapid_pubkey: VapidPublicKeyB64("test".to_string()),
+        advertise_vcard4,
+    };
+
+    let xml = resource
+        .propfind(
+            &format!(
+                "/carddav/principal/{}/{}",
+                addressbook.principal, addressbook.id
+            ),
+            &propfind.prop,
+            propfind.include.as_ref(),
+            &CardDavPrincipalUri("/carddav"),
+            &principal,
+        )
+        .unwrap()
+        .serialize_to_string()
+        .unwrap();
+
+    assert!(
+        xml.contains(r#"version="3.0""#),
+        "vCard 3.0 must always be advertised: {xml}"
+    );
+    assert_eq!(
+        xml.contains(r#"version="4.0""#),
+        expect_vcard4,
+        "advertise_vcard4={advertise_vcard4}: {xml}"
+    );
 }

--- a/crates/carddav/src/lib.rs
+++ b/crates/carddav/src/lib.rs
@@ -16,6 +16,7 @@ use rustical_store::{
     AddressbookStore,
     auth::{AuthenticationProvider, Principal},
 };
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 pub mod address_object;
@@ -42,14 +43,41 @@ impl PrincipalUri for CardDavPrincipalUri {
     }
 }
 
+const fn default_true() -> bool {
+    true
+}
+
+/// `CardDAV` server options.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields, default)]
+pub struct CardDavConfig {
+    /// Advertise vCard 4.0 in `supported-address-data`.
+    ///
+    /// Set to `false` when macOS Contacts shares the address book. Apple's
+    /// client rejects vCard 4.0 and fails the whole sync; `DAVx5` writes 4.0
+    /// whenever the server advertises it. RFC 6352 only requires accepting
+    /// advertised versions, so 4.0 PUTs still work.
+    #[serde(default = "default_true")]
+    pub advertise_vcard4: bool,
+}
+
+impl Default for CardDavConfig {
+    fn default() -> Self {
+        Self {
+            advertise_vcard4: true,
+        }
+    }
+}
+
 pub fn carddav_router<AP: AuthenticationProvider, A: AddressbookStore, DP: DavPushStore>(
     prefix: &'static str,
     auth_provider: Arc<AP>,
     store: Arc<A>,
     dav_push_store: Arc<DP>,
+    config: Arc<CardDavConfig>,
 ) -> Router {
     let principal_service =
-        PrincipalResourceService::new(store, auth_provider.clone(), dav_push_store);
+        PrincipalResourceService::new(store, auth_provider.clone(), dav_push_store, config);
     Router::new()
         .nest(
             prefix,
@@ -78,5 +106,10 @@ mod tests {
             CardDavPrincipalUri("/carddav").principal_uri(principal),
             output
         );
+    }
+
+    #[test]
+    fn carddav_config_defaults_to_advertising_vcard4() {
+        assert!(crate::CardDavConfig::default().advertise_vcard4);
     }
 }

--- a/crates/carddav/src/principal/service.rs
+++ b/crates/carddav/src/principal/service.rs
@@ -1,3 +1,4 @@
+use crate::CardDavConfig;
 use crate::CardDavPrincipalUri;
 use crate::Error;
 use crate::addressbook::AddressbookResourceService;
@@ -19,6 +20,7 @@ pub struct PrincipalResourceService<
     addr_store: Arc<A>,
     auth_provider: Arc<AP>,
     dav_push_store: Arc<DP>,
+    config: Arc<CardDavConfig>,
 }
 
 impl<A: AddressbookStore, AP: AuthenticationProvider, DP: DavPushStore> Clone
@@ -29,6 +31,7 @@ impl<A: AddressbookStore, AP: AuthenticationProvider, DP: DavPushStore> Clone
             addr_store: self.addr_store.clone(),
             auth_provider: self.auth_provider.clone(),
             dav_push_store: self.dav_push_store.clone(),
+            config: self.config.clone(),
         }
     }
 }
@@ -36,11 +39,17 @@ impl<A: AddressbookStore, AP: AuthenticationProvider, DP: DavPushStore> Clone
 impl<A: AddressbookStore, AP: AuthenticationProvider, DP: DavPushStore>
     PrincipalResourceService<A, AP, DP>
 {
-    pub const fn new(addr_store: Arc<A>, auth_provider: Arc<AP>, dav_push_store: Arc<DP>) -> Self {
+    pub const fn new(
+        addr_store: Arc<A>,
+        auth_provider: Arc<AP>,
+        dav_push_store: Arc<DP>,
+        config: Arc<CardDavConfig>,
+    ) -> Self {
         Self {
             addr_store,
             auth_provider,
             dav_push_store,
+            config,
         }
     }
 }
@@ -85,6 +94,7 @@ impl<A: AddressbookStore, AP: AuthenticationProvider, DP: DavPushStore> Resource
             .map(|addressbook| AddressbookResource {
                 addressbook,
                 vapid_pubkey: vapid_pubkey.clone(),
+                advertise_vcard4: self.config.advertise_vcard4,
             })
             .collect())
     }
@@ -96,6 +106,7 @@ impl<A: AddressbookStore, AP: AuthenticationProvider, DP: DavPushStore> Resource
                 AddressbookResourceService::new(
                     self.addr_store.clone(),
                     self.dav_push_store.clone(),
+                    self.config.clone(),
                 )
                 .axum_router(),
             )

--- a/docs/setup/client.md
+++ b/docs/setup/client.md
@@ -65,6 +65,19 @@ This is because Apple does not properly adhere to the CalDAV specification (whic
 **Note**: Since Apple Calendar does not properly support the `calendar-home-set` property the `/caldav-compat` endpoints should be used.
 That also means that Apple Calendar is not able to automatically discover group collections so in that case you'll have to manually add all principals with `/caldav-compat/principal/<principal_id>`.
 
+## Apple Contacts
+
+macOS Contacts rejects vCard 4.0 and then marks the whole address-book sync as failed. Clients such as DAVx5 write 4.0 whenever the server advertises it.
+
+If Apple Contacts shares an address book with those clients, disable advertising vCard 4.0:
+
+```toml
+[carddav]
+advertise_vcard4 = false
+```
+
+The server still accepts 4.0 PUTs; it just stops listing 4.0 in `supported-address-data` so new writes stay on 3.0.
+
 ## Evolution
 
 Set up a collection account in the account settings.

--- a/src/app.rs
+++ b/src/app.rs
@@ -10,7 +10,7 @@ use headers::{HeaderMapExt, UserAgent};
 use http::header::CONNECTION;
 use http::{HeaderValue, StatusCode};
 use rustical_caldav::{CalDavConfig, caldav_router};
-use rustical_carddav::carddav_router;
+use rustical_carddav::{CardDavConfig, carddav_router};
 use rustical_dav_push::DavPushStore;
 use rustical_frontend::nextcloud_login::nextcloud_login_router;
 use rustical_frontend::{FrontendConfig, frontend_router};
@@ -47,6 +47,7 @@ pub fn make_app<
     frontend_config: FrontendConfig,
     oidc_config: Option<OidcConfig>,
     caldav_config: CalDavConfig,
+    carddav_config: CardDavConfig,
     nextcloud_login_config: &NextcloudLoginConfig,
     dav_push_enabled: bool,
     session_cookie_samesite_strict: bool,
@@ -101,6 +102,7 @@ pub fn make_app<
             auth_provider.clone(),
             addr_store.clone(),
             dav_push_store.clone(),
+            Arc::new(carddav_config),
         ));
 
     // GNOME Accounts needs to discover a WebDAV Files endpoint to complete the setup

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -4,6 +4,7 @@ use crate::config::{
 };
 use clap::Parser;
 use rustical_caldav::CalDavConfig;
+use rustical_carddav::CardDavConfig;
 use rustical_frontend::FrontendConfig;
 
 pub mod app_token;
@@ -22,6 +23,7 @@ pub fn cmd_gen_config(_args: GenConfigArgs) -> anyhow::Result<()> {
     let config = Config {
         http: HttpConfig::default(),
         caldav: CalDavConfig::default(),
+        carddav: CardDavConfig::default(),
         data_store: DataStoreConfig::Sqlite(SqliteDataStoreConfig {
             db_url: "/var/lib/rustical/db.sqlite3".to_owned(),
             run_repairs: true,

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,6 +4,7 @@ use std::{path::PathBuf, str::FromStr};
 use anyhow::anyhow;
 use reqwest::Url;
 use rustical_caldav::CalDavConfig;
+use rustical_carddav::CardDavConfig;
 use rustical_frontend::FrontendConfig;
 use rustical_oidc::OidcConfig;
 use serde::{Deserialize, Serialize};
@@ -266,6 +267,9 @@ pub struct Config {
     pub nextcloud_login: NextcloudLoginConfig,
     #[serde(default)]
     pub caldav: CalDavConfig,
+    /// `CardDAV` options. Set `advertise_vcard4 = false` when macOS Contacts shares the address book.
+    #[serde(default)]
+    pub carddav: CardDavConfig,
     #[serde(default)]
     pub maintenance: MaintenanceConfig,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,6 +146,7 @@ pub async fn cmd_serve(
         config.frontend.clone(),
         config.oidc.clone(),
         config.caldav,
+        config.carddav,
         &config.nextcloud_login,
         config.dav_push.enabled,
         config.http.session_cookie_samesite_strict,

--- a/src/main.rs
+++ b/src/main.rs
@@ -169,4 +169,30 @@ allow_sign_up = true
             Ok(())
         });
     }
+
+    #[test]
+    fn test_config_toml_carddav_advertise_vcard4() {
+        let with_flag = r#"
+[data_store.sqlite]
+db_url = "/var/lib/rustical/db.sqlite3"
+
+[carddav]
+advertise_vcard4 = false
+"#;
+        let config: Config = Figment::new()
+            .merge(Toml::string(with_flag))
+            .extract()
+            .unwrap();
+        assert!(!config.carddav.advertise_vcard4);
+
+        let omitted = r#"
+[data_store.sqlite]
+db_url = "/var/lib/rustical/db.sqlite3"
+"#;
+        let config: Config = Figment::new()
+            .merge(Toml::string(omitted))
+            .extract()
+            .unwrap();
+        assert!(config.carddav.advertise_vcard4);
+    }
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -66,6 +66,7 @@ pub fn rustical_process(
                     dav_push: Default::default(),
                     nextcloud_login: Default::default(),
                     caldav: Default::default(),
+                    carddav: Default::default(),
                     maintenance: Default::default(),
                 },
                 Some(cloned_start_notify),

--- a/tests/http_integration.rs
+++ b/tests/http_integration.rs
@@ -97,6 +97,7 @@ async fn test_initial_setup() {
                 dav_push: Default::default(),
                 nextcloud_login: Default::default(),
                 caldav: Default::default(),
+                carddav: Default::default(),
                 maintenance: Default::default(),
             },
         )
@@ -127,6 +128,7 @@ async fn test_initial_setup() {
                 dav_push: Default::default(),
                 nextcloud_login: Default::default(),
                 caldav: Default::default(),
+                carddav: Default::default(),
                 maintenance: Default::default(),
             },
         )
@@ -234,6 +236,7 @@ async fn test_principal_impersonation() {
             dav_push: Default::default(),
             nextcloud_login: Default::default(),
             caldav: Default::default(),
+            carddav: Default::default(),
             maintenance: Default::default(),
         };
 

--- a/tests/integration_tests/mod.rs
+++ b/tests/integration_tests/mod.rs
@@ -3,6 +3,7 @@ use axum::{body::Body, response::Response};
 use rstest::rstest;
 use rustical::{app::make_app, config::NextcloudLoginConfig};
 use rustical_caldav::CalDavConfig;
+use rustical_carddav::CardDavConfig;
 use rustical_frontend::FrontendConfig;
 use rustical_store_sqlite::tests::{TestStoreContext, test_store_context};
 use std::sync::Arc;
@@ -28,6 +29,7 @@ pub fn get_app(context: TestStoreContext) -> axum::Router {
         },
         None,
         CalDavConfig::default(),
+        CardDavConfig::default(),
         &NextcloudLoginConfig { enabled: false },
         false,
         true,


### PR DESCRIPTION
## Summary
- Adds `[carddav] advertise_vcard4` (default `true`) so servers shared with macOS Contacts can drop vCard 4.0 from `supported-address-data`.
- Clients such as DAVx5 write 4.0 whenever the server advertises it; Apple Contacts then rejects those cards and fails the whole address-book sync.
- 4.0 PUTs are still accepted (RFC 6352 only requires accepting advertised versions). Fixes https://github.com/lennart-k/rustical/issues/265.

## Test plan
- [ ] `cargo test -p rustical_carddav --lib`
- [ ] Confirm default PROPFIND still lists `text/vcard` 3.0 and 4.0
- [ ] Set `advertise_vcard4 = false` and confirm PROPFIND lists only 3.0
- [ ] PUT a vCard 4.0 with the flag off and confirm the server still accepts it
- [ ] With the flag off, create a contact in DAVx5 and confirm macOS Contacts syncs it


Made with [Cursor](https://cursor.com)